### PR TITLE
fix(e2e): correct GraphQL Dockerfile path in docker-compose.e2e.yml

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -29,7 +29,7 @@ services:
   graphql-service:
     build:
       context: .
-      dockerfile: cmd/hrms-server/query-unified/Dockerfile
+      dockerfile: cmd/hrms-server/query/Dockerfile
     environment:
       - DATABASE_URL=postgres://user:password@postgres:5432/cubecastle?sslmode=disable
       - REDIS_ADDR=redis:6379


### PR DESCRIPTION
Use cmd/hrms-server/query/Dockerfile to fix e2e stack build failure. No port mapping changes.