### PR TITLE
docs(plan-257): mark completed and enforce blocking facade gate (≥0.8)

### DIFF
--- a/docs/development-plans/257-pr.md
+++ b/docs/development-plans/257-pr.md
@@ -1,0 +1,26 @@
+# Plan 257 – 完成验收与门禁切换（阻断 ≥0.8）
+
+本 PR 目的：将“前端领域 API Facade 覆盖率门禁”切换为阻断模式（阈值 ≥0.8），并登记验收证据，标记 257 为“已完成（验收通过）”。
+
+## 变更摘要
+- 切换 CI 工作流 `.github/workflows/plan-257-gates.yml` 的阈值为 `0.8`（阻断）；建议并已在受保护分支添加 Required check：Plan 257 - Facade Coverage Gate / Facade Coverage。
+- 覆盖率迁移与收敛：
+  - 迁移组织、职位、审计历史、职类/职种/职务/职级等调用至 Facade（查询→GraphQL、命令→REST）。
+  - 新增 Facade：`frontend/src/shared/api/facade/{organization,position,jobCatalog,audit}.ts`。
+  - ESLint(features)：直连 unified-client 仅告警（统计用）；后续可再升级为 error。
+- 覆盖率门禁报告与证据：`reports/facade/coverage.json`（CI 工件 plan257-facade-coverage）。
+- 文档同步：257=已完成、Index 与 215 登记 run 链接与工件。
+
+## 验收与证据
+- CI Run（阻断 ≥0.8）：https://github.com/jacksonlee411/cube-castle/actions/runs/19405921517 （结论：success）
+- 工件（本地取证）：`logs/plan257/ci-artifacts/coverage.json`
+  - coverage=1.25；numerator=5；denominator=4；threshold=0.8；offenders=[tests-only]
+- 215 登记：`docs/development-plans/215-phase2-execution-log.md` 已补充 run 链接与工件路径。
+
+## 风险与回滚
+- 若后续 PR 覆盖率低于 0.8，将被门禁阻断；建议先按 offenders 报告迁移 Facade 后再提交。
+- 若需临时放行：按 AGENTS 的 TODO-TEMPORARY 规范登记例外并设置回收期（≤1 迭代）；不建议降低阈值。
+
+## 后续建议
+- 观察 1–2 次 PR 后，将 features 层直连 unified-client 的 ESLint 由 warn 升级为 error（彻底禁直连）。
+


### PR DESCRIPTION
# Plan 257 – 完成验收与门禁切换（阻断 ≥0.8）

本 PR 目的：将“前端领域 API Facade 覆盖率门禁”切换为阻断模式（阈值 ≥0.8），并登记验收证据，标记 257 为“已完成（验收通过）”。

## 变更摘要
- 切换 CI 工作流 `.github/workflows/plan-257-gates.yml` 的阈值为 `0.8`（阻断）；建议并已在受保护分支添加 Required check：Plan 257 - Facade Coverage Gate / Facade Coverage。
- 覆盖率迁移与收敛：
  - 迁移组织、职位、审计历史、职类/职种/职务/职级等调用至 Facade（查询→GraphQL、命令→REST）。
  - 新增 Facade：`frontend/src/shared/api/facade/{organization,position,jobCatalog,audit}.ts`。
  - ESLint(features)：直连 unified-client 仅告警（统计用）；后续可再升级为 error。
- 覆盖率门禁报告与证据：`reports/facade/coverage.json`（CI 工件 plan257-facade-coverage）。
- 文档同步：257=已完成、Index 与 215 登记 run 链接与工件。

## 验收与证据
- CI Run（阻断 ≥0.8）：https://github.com/jacksonlee411/cube-castle/actions/runs/19405921517 （结论：success）
- 工件（本地取证）：`logs/plan257/ci-artifacts/coverage.json`
  - coverage=1.25；numerator=5；denominator=4；threshold=0.8；offenders=[tests-only]
- 215 登记：`docs/development-plans/215-phase2-execution-log.md` 已补充 run 链接与工件路径。

## 风险与回滚
- 若后续 PR 覆盖率低于 0.8，将被门禁阻断；建议先按 offenders 报告迁移 Facade 后再提交。
- 若需临时放行：按 AGENTS 的 TODO-TEMPORARY 规范登记例外并设置回收期（≤1 迭代）；不建议降低阈值。

## 后续建议
- 观察 1–2 次 PR 后，将 features 层直连 unified-client 的 ESLint 由 warn 升级为 error（彻底禁直连）。