### PR TITLE
docs: restructure som plans

### DIFF
--- a/docs/development-plans/00-README.md
+++ b/docs/development-plans/00-README.md
@@ -28,7 +28,12 @@
 - `271-archive-integrity-guard.md`—— Plan 271，归档守卫、CI 自动化与 `lint:docs` 规则。
 - `272-runtime-artifact-cleanup.md`—— Plan 272，运行产物与 cloc 噪音压降（Stage1 logs/reports/test-results，Stage2 vendored 依赖治理）。
 - `400-standard-object-model-plan.md`—— 将组织/职位等对象抽象为统一 SOM，覆盖生命周期、契约、UI、迁移策略。
-- `402-standard-object-single-source-plan.md`—— 评估单表模式缺陷，制定 SOM 三表迁移蓝图与执行路线，保障唯一事实来源。
+- `402-standard-object-single-source-plan.md`—— 评估单表模式缺陷，制定 SOM 三表迁移蓝图；执行细节拆分为 402A~402E 子计划（映射/契约、schema/tooling、服务接入与双写、切换回收、收敛治理）。子计划文件：
+  - `402A-standard-object-mapping-and-contracts.md`
+  - `402B-som-schema-and-tooling.md`
+  - `402C-service-integration-and-double-write.md`
+  - `402D-cutover-and-recovery.md`
+  - `402E-convergence-and-governance.md`
 
 > 新增计划需遵循 `docs/development-plans/<id>-<slug>.md` 命名，并立即在此处补充一句描述与事实来源。
 

--- a/docs/development-plans/400-standard-object-model-plan.md
+++ b/docs/development-plans/400-standard-object-model-plan.md
@@ -51,30 +51,42 @@
 | 模块 | 说明 | 对应产物 |
 |------|------|----------|
 | `ObjectKernel` | 核心对象结构，含 `objectType`, `code`, `displayName`, `status`, `tenant`, `labels`, `createdBy` | `internal/standardobject/domain/object.go` |
-| `TemporalVersion` | 版本信息：`versionCode`, `effectiveFrom`, `effectiveTo`, `payload`（JSONB）、`auditTrail` | `standard_object_versions` 表 + sqlc |
+| `TemporalVersion` | 版本信息：`versionCode`, `effectiveDate`, `endDate`, `payload`（JSONB）、`auditTrail` | `standard_object_versions` 表 + sqlc |
 | `LifecyclePolicy` | 不同对象类型的状态转换/校验策略（组织可滞后，职位需校验梯队/编制） | `internal/standardobject/policy/*.go` |
 | `Link` | 层级与挂载关系，支持 parent-child、position->organization | `standard_object_links` 表、GraphQL `StandardObjectLink` |
 | `EventEnvelope` | 向 outbox 写 `standard_object.created/updated/versioned/status_changed` | `pkg/eventbus` + dispatcher |
+| `SchemaRegistry` | 管理 payload schema 版本、ISO 11179 Data Element Concept（DEC）语义 ID、OCL 守卫与发布策略，供后端/前端/生成脚本读取 | `standard_object_schemas` 表 + 文档化流程 |
+| `Translation`/`Attachment` | 多语言 label、外部文档/批复等扩展维度 | `standard_object_translations`、`standard_object_attachments` |
+| `Observability & Metrics` | 记录快照刷新、校验差异、事件消费等指标/OBS 事件 | `standard_object_metrics`、日志规范 |
+
+#### 4.1.1 语义锚点与 OCL 验证
+- Schema Registry 需与 Plan 403 提出的 ISO 11179 语义锚点保持一致：每个 payload 字段都绑定 Data Element Concept（DEC）ID、语义版本、可选同义词列表。`schema-registry.json` 在生成时必须输出 `{ fieldPath, decId, glossaryUrl }` 结构，QA 在 `logs/plan400/schema/*.log` 验证缺失项。
+- 同一 Schema 条目携带 `oclGuard` 数组，落地 403 文档的“组合层 OCL”要求。命令服务在写入前、migration/validator/Playwright 在验收前均调用共享 `pkg/ocl` 引擎执行 `preState`/`postState` 校验，违反则返回 `422 STANDARD_OBJECT_OCL_VIOLATION`。
+- Manifest/前端生成脚本使用 DEC ID 决定显示名称、默认提示与多语言描述，确保 UI/文档的唯一语义来源；任何新增字段若未在 Schema Registry 注册 DEC，将被 `scripts/quality/architecture-validator.js` 阻断。
 
 ### 4.2 生命周期与状态机
 状态：`DRAFT` → `READY` → `ACTIVE` → `SUSPENDED` → `RETIRED`。  
 规则：
 1. `READY` 仅可由 `DRAFT` 进入，需通过类型特定 `LifecyclePolicy.ValidateReady`.
-2. `ACTIVE` 必须有至少一个有效版本，版本的 `effectiveFrom` ≤ 当前时间。
+2. `ACTIVE` 必须有至少一个有效版本，版本的 `effectiveDate` ≤ 当前时间。
 3. `SUSPENDED` 可返回 `ACTIVE`，需记录原因（存储在版本 payload 内 `suspensionNote`）。
 4. `RETIRED` 为终态，不可再创建新版本；组织/职位 retire 时必须广播事件 `standard_object.retired`.
 5. 所有状态变更经由 `ObjectCommandService`（REST）执行，保证 CQRS 原则。
 
 ### 4.3 数据模型与迁移
 新增 Goose/Atlas 迁移（示例字段）：
-- `standard_objects`: `id (uuid)`, `code (text unique)`, `object_type`, `tenant_code`, `display_name`, `status`, `labels jsonb`, `created_by`, `created_at`, `updated_at`.
-- `standard_object_versions`: `id`, `object_id`, `version_code`, `effective_from`, `effective_to`, `payload jsonb`, `is_current`, `audit jsonb`.
-- `standard_object_links`: `id`, `source_object_id`, `target_object_id`, `link_type`, `attributes jsonb`.
+- `standard_objects`: `id (uuid)`, `code (text unique)`, `object_type`, `object_type_potency smallint`, `object_type_inheritance text`, `tenant_code`, `display_name`, `status`, `labels jsonb`, `created_by`, `created_at`, `updated_at`.
+- `standard_object_versions`: `id`, `object_id`, `version_code`, `effective_date`, `end_date`, `payload jsonb`, `is_current`, `audit jsonb`, `checksum`, `created_at`, `updated_at`.
+- `standard_object_links`: `id`, `source_object_id`, `target_object_id`, `link_type`, `attributes jsonb`, `tenant_code`, `created_by`, `created_at`, `updated_at`, `updated_by`.
+- `standard_object_schemas`: `id`, `object_type`, `schema_version`, `schema_hash`, `definition jsonb`, `dec_bindings jsonb`, `ocl_guards jsonb`, `glossary_url text`, `published_at`, `rollback_version`, `maintainer`.
+- `standard_object_translations`: `id`, `object_id`, `locale`, `display_name`, `description`, `labels jsonb`, `updated_at`, `updated_by`.
+- `standard_object_attachments`: `id`, `object_id`, `attachment_type`, `storage_uri`, `metadata jsonb`, `uploaded_by`, `uploaded_at`.
+- `standard_object_metrics`: `id`, `object_id`, `metric_type`, `metric_value numeric`, `recorded_at`, `labels jsonb`。
 
 实现要求：
-1. 采用 sqlc（Plan 201 差异项）生成仓储接口，生成命令置于 `internal/standardobject/repository/sqlc`.
-2. `internal/organization`、`internal/position` 仅通过 `ObjectService` 访问公共仓储；保留特定字段（如组织扩展属性）通过 `payload` + schema 校验。
-3. 迁移脚本命名 `20251201090000_create_standard_objects.sql`，必须包含 Up/Down。
+1. 采用 sqlc（Plan 201 差异项）生成仓储接口，生成命令置于 `internal/standardobject/repository/sqlc`；接口需提供 `LookupObjectTypeMetadata` 以读取 potency/继承策略。
+2. `internal/organization`、`internal/position` 仅通过 `ObjectService` 访问公共仓储；保留特定字段（如组织扩展属性）通过 `payload` + schema 校验。`ObjectService` 在创建/迁移时必须校验 `object_type_potency` 与 Schema Registry 中的 `dec_bindings`/`ocl_guards`。
+3. 迁移脚本命名 `20251201090000_create_standard_objects.sql`，必须包含 Up/Down，并在同一批次创建 Schema Registry、Translation、Attachment、Metrics 等扩展表；Schema Registry 表需包含 `dec_bindings`（字段路径 → DEC ID/语义版本）、`ocl_guards`（数组）、`glossary_url` 等列；操作规范需更新至 `docs/reference`。
 
 ### 4.4 契约与 API
 1. **REST**：`POST /standard-objects/{objectType}` 创建对象，`POST /standard-objects/{objectType}/{code}/versions` 创建版本，`PATCH /standard-objects/{objectType}/{code}/status`，`GET /standard-objects/{objectType}` 列表。路径参数统一 `{objectType}/{code}`。
@@ -87,6 +99,7 @@
 2. `OrganizationTemporalPage` 与 `PositionTemporalPage` 只注入对象类型、字段映射、表单 schema；页面骨架、tab、版本操作复用 `TemporalEntityLayout`。
 3. 表单配置：采用 JSON Schema + 动态组件，放置 `frontend/src/shared/forms/standard-object`，便于 workforce/contract 共享。
 4. Playwright：新增 `frontend/tests/e2e/standard-object-lifecycle.spec.ts`，收敛 selectors（`temporalEntitySelectors.*`），`logs/plan400/ui/*.log` 落盘 `[OBS]` 事件。
+5. Manifest/Schema 生成：结合 Plan 300，在 `scripts/generate-forms-from-openapi.ts`、`scripts/generate-columns-from-graphql.ts`、`schema-registry.json` 输出中引入 SOM 实体，记录证据到 `logs/plan400/manifest/*.log`。
 
 ### 4.6 开发阶段（建议 4 Sprint）
 | 阶段 | 时间 | 交付 | 依赖 |
@@ -102,6 +115,24 @@
 - **物化视图**：为常用日期（如 `CURRENT_DATE`、每月 1 日）创建 `CREATE MATERIALIZED VIEW standard_object_snapshot_mv AS ...`，并在 `cmd/tools/standardobject-snapshot-refresh` 中调用 `REFRESH MATERIALIZED VIEW CONCURRENTLY`。
 - **刷新流程**：Outbox dispatcher 捕获 `standard_object.*` 事件后，将任务写入刷新队列，Go Job 或 SQL 调度器（例如 `pg_cron`）执行 `UPSERT`/`DELETE + INSERT` 更新快照；运行日志写入 `logs/plan400/snapshots/*.log`。
 - **查询策略**：REST/GraphQL 读路径优先命中快照/物化视图；若缺少特定日期快照，则即时计算并触发异步刷新，保证体验。
+
+### 4.8 多视点矩阵
+结合 Plan 403 的 Multi-view Projection Pattern，SOM 的契约/实现/证据必须以视点矩阵交付：
+
+| 视点 | 关注点 | 产物/证据 |
+|------|--------|-----------|
+| **结构视点** | ObjectKernel/Link、Schema Registry、DEC 列表 | `docs/api/*`, `schema-registry.json`, `logs/plan400/schema/*.log` |
+| **运行视点** | 状态机、版本事件、快照/闭包刷新、Outbox 指标 | `pkg/eventbus` 事件、`standard_object_hierarchy_snapshots`, `logs/plan400/snapshots/*.log` |
+| **观察视点** | OBS 事件、Playwright 选择器守卫、性能指标 | `logs/plan400/ui/*.log`, `[OBS] standardObject.*` 事件、`standard_object_metrics` |
+| **协作视点** | Manifest/Slot 注册、PBAC scope、生成器输出 | `frontend/src/features/temporal/*`, `scripts/generate-*` 证据、`scripts/quality/auth-permission-contract-validator.js` |
+
+任何新增模块（如 contract/workforce）需声明其视点覆盖关系，并在 PR/验收模板中粘贴对应矩阵条目，避免“契约→实现→证据”跨层不一致。
+
+### 4.9 多级建模与对象类型效力
+为满足 403 文档提出的 Deep Instantiation 要求：
+- `objectType` 元数据引入 `potency`（默认 1）。`potency>1` 的类型（例如“POSITION_FAMILY”）可以在 M1 层继续派生子类型，再在 M0 赋值字段。Schema Registry 需记录 `potency`、允许派生的属性以及 `inheritanceStrategy`（`FIXED`/`EXTENDABLE`）。
+- `internal/standardobject/policy` 在加载类型配置时校验 `potency` 与状态机是否兼容（例如 `potency=2` 的类型在派生层同样遵循 `DRAFT→ACTIVE`）。
+- Migrator/Validator 需对旧表数据生成默认的 `potency=1` 记录，并在 `logs/plan400/migration/*.log` 给出“未声明 potency 的对象类型数量”，以防扩展时遗漏模型层语义。
 
 ---
 
@@ -142,6 +173,21 @@
 - Phase4 contract 模块接入 SOM（单独开 Plan 4xx 子文档）。
 - 将 SOM 纳入 `docs/reference/01-DEVELOPER-QUICK-REFERENCE.md`，提供统一入口。
 - 评估将 SOM 事件写入数据仓库或审计总线的需求（与 `pkg/eventbus` Redis Adapter 计划同步）。
+
+---
+
+## 10. 与 Plan 200/201 的对齐要求
+
+为确保本方案完全继承 200/201 的工程基线，以下守卫为强制项：
+
+1. **端口/适配器模式**：`internal/standardobject/api.go` 暴露的接口需要在 `cmd/hrms-server/*` 入口统一注入，禁止服务层直接引用仓储实现。所有依赖关系必须通过 Go 原生的端口/适配器结构与 `internal/.../adapter` 目录实现。
+2. **sqlc + Atlas Pipeline**：仓库根需保留 `make sqlc-generate`、`atlas migrate diff` 守卫；在 PR/验收阶段必须提供 `logs/plan400/sqlc-generate.log`、`logs/plan400/atlas-diff.log`，证明生成产物与迁移脚本为最新版本。
+3. **Docker-first 测试**：所有数据库/集成测试须运行 `make test-db`（调用 `scripts/run-integration-tests.sh`，在 Docker Compose 中执行 Goose Up → Go Integration Tests → Goose Down），并在 `logs/plan400/test-db/*.log` 落证；禁止依赖宿主 PostgreSQL。
+4. **事务性发件箱与持久化 EventBus**：Outbox dispatcher 必须注入 Plan 201 规划的持久化传输（Redis/Faktory/Asynq adapter），并在 `pkg/eventbus` 层提供指标；`STANDARD_OBJECTS` 相关事件不得使用内存总线。
+5. **PBAC 外部化**：Plan 252/259 的策略源需纳入 Schema Registry/对象模型，命令/查询服务不得硬编码 scope；验收时需提供 `scripts/quality/auth-permission-contract-validator.js` 报告。
+6. **质量守卫**：在 `scripts/quality/*`（Plan 255/258/259）中新增/更新规则以检查 Schema Registry、Manifest/Slot、禁止 `_from/_to` 命名等；CI 必须运行 `make lint`, `make fmt`, `npm run lint`, `npm run quality:preflight` 并附日志。
+
+只有在满足以上守卫并提供相应日志的情况下，SOM 交付才视为与 Plan 200/201 对齐。
 
 ---
 

--- a/docs/development-plans/401-HRMS 时态数据与性能优化.md
+++ b/docs/development-plans/401-HRMS 时态数据与性能优化.md
@@ -35,20 +35,23 @@ HRMS 的架构演进已经在 Plan 400 中确认以 **Standard Object Model（SO
 
 SOM 将所有“可被时间管理的业务对象”抽象为同一个编排单元，并用对象类型（`objectType`）区分组织（`organization.unit`）、职位（`position.role`）以及未来的 workforce/contract 实体：
 
-* **ObjectKernel** – `standard_objects`：承载 `code`、`displayName`、`status`、`tenantCode`、`labels`、`createdBy` 等公共属性。每条记录都附带 `createdAt/updatedAt` 以满足审计和回滚需要。  
-* **TemporalVersion** – `standard_object_versions`：以 `versionCode` + `effective_from`/`effective_to` 捕捉时间维度。所有可配置 payload（JSONB）与 `auditTrail` 都放在版本层，保证“变更 = 新版本”而非覆盖式修改。  
-* **Link** – `standard_object_links`：用于维护 parent-child、position-to-organization、跨对象引用等层级关系。`linkType` + `attributes` 允许扩展更多类型的关系（例如 cost center、location）。
+* **ObjectKernel** – `standard_objects`：承载 `code`、`displayName`、`status`、`tenantCode`、`labels`、`schemaVersion`、`dataClassification`、`retentionPolicy` 等公共属性，并记录 `createdAt/updatedAt`/`createdBy`；该层负责对象级治理与权限派生。  
+* **TemporalVersion** – `standard_object_versions`：以 `versionCode` + `effective_date`/`end_date` 捕捉时间维度。所有版本化 payload（JSONB）与 `auditTrail`（changeReason/operation/actor…）都放在版本层，保证“变更 = 新版本”而非覆盖式修改。  
+* **Link** – `standard_object_links`：用于维护 parent-child、position-to-organization、跨对象引用等关系。`linkType` + `attributes`（sortOrder、hierarchyDepth、path 缓存、effectiveDate 等）允许扩展更多类型的挂载。  
+* **SchemaRegistry** – `standard_object_schemas`：记录各对象类型的 payload schema、hash、发布/回滚策略，为生成脚本（Plan 300）与校验器提供唯一事实来源。  
+* **Translations & Attachments** – `standard_object_translations`、`standard_object_attachments`：存放多语言展示文本、外部文档/批复等扩展维度，支撑全球化体验与合规审计。  
+* **Observability & Metrics** – `standard_object_metrics`（以及 `logs/plan400/*`）收集快照刷新、validator 差异、事件消费耗时等指标，供 Plan 272/402 的治理脚本消费。
 
-通过 SOM，组织/职位共享 `ObjectService`/`LifecyclePolicy`/`MetadataRepository` 等接口（参见 Plan 400），减少重复实现，也为 future modules 预留了统一入口。
+通过 SOM，组织/职位共享 `ObjectService`/`LifecyclePolicy`/`MetadataRepository` 等接口（参见 Plan 400），并由 Schema Registry/Translation/Attachment/Observability 模块提供扩展治理能力，减少重复实现，也为 future modules 预留统一入口。所有命名必须遵循 Plan 400/402 的“仅使用 `effective_date/end_date`”规则，禁止新增 `_from/_to` 变体。
 
 ### **2.2 SQL-first + sqlc 生成链**
 
 为了维持“迁移即真源”，SOM 采用 SQL-first 的管线：
 
-1. **Atlas schema** 描述数据库目标状态；  
-2. `atlas migrate diff` 生成 Goose 迁移（含 Up/Down），被纳入 `database/migrations/*`；  
-3. `sqlc generate` 解析上述 SQL/查询语句，输出类型安全的 Go 仓储代码；  
-4. 命令/查询服务通过接口层组合 sqlc 生成物，与事务性发件箱、PBAC 守卫共享相同的依赖注入模式。
+1. **Atlas schema** 描述数据库目标状态（含 `standard_object_schemas`、`standard_object_translations`、`standard_object_attachments`、`standard_object_metrics` 等扩展表）；  
+2. `atlas migrate diff` 生成 Goose 迁移（含 Up/Down），被纳入 `database/migrations/*`，确保扩展表与三表同步管理；  
+3. `sqlc generate` 解析上述 SQL/查询语句，输出类型安全的 Go 仓储代码，并同步生成 Schema Registry/Translation/Attachment/Metric DAO；  
+4. Schema Registry 通过 `schema-registry.json` 与 `scripts/generate-forms-from-openapi.ts` 等 Plan 300 工具共享；命令/查询服务通过接口层组合 sqlc 生成物，与事务性发件箱、PBAC 守卫共享相同的依赖注入模式。
 
 这种方式既保留了 DBA 友好的 SQL，可直接调优 `tstzrange`/GiST 索引，又能在编译期发现字段漂移，符合 200/201 号文档强调的“少依赖黑盒框架、保持透明”的长期原则。
 
@@ -172,6 +175,8 @@ HRMS 的读侧需要处理大量带时间过滤的复杂查询。我们依旧采
 2. **物化视图（Materialized View）**：针对审计常用的时间片（如每月 1 号、季度末）建立 `CREATE MATERIALIZED VIEW employee_roster_mv_20250101 AS ...`，利用 `REFRESH MATERIALIZED VIEW CONCURRENTLY` 在后台刷新，暴露给 GraphQL/REST 查询。
 
 当用户查询非常规日期时，可调用存储过程 `SELECT * FROM fetch_roster_snapshot($1)`：若快照存在则直接读取，否则运行一次按需计算并缓存结果，避免重复消耗。结合 PostgreSQL `pg_cron`/`SQL` Job，整个链路仍然只依赖数据库自身。
+
+此外，快照刷新/物化视图操作必须将关键指标写入 `standard_object_metrics`（例如刷新耗时、批量大小、差异计数），并同步输出到 `logs/plan400/snapshots/*.log`、`logs/plan400/metrics/*.log`。Plan 272/402 的治理脚本会读取这些指标，以监控读模型的可用性与延迟。
 
 ### **4.3 解决 SQL 复杂度爆炸：维度快照技术**
 
@@ -301,6 +306,19 @@ Oracle 提出了 **DateTrack** 概念，支持 Correction（修正历史）和 U
 | **维度关联** | 关联自然主键 (Natural Key) | 关联代理主键 (Surrogate Key) | 避免维度调整导致事实表的海量数据迁移。 |
 
 此架构蓝图旨在为技术决策者提供清晰的路径，平衡理论的完美性与工程的落地性。
+
+---
+
+## **8\. 与 Plan 200/201 的工程守卫对齐**
+
+1. **端口/适配器与 internal 结构**：所有时态作业、Schema Registry 服务、读模型刷新器必须通过 `internal/standardobject/**` 或独立模块定义接口，由 `cmd/hrms-server/*` / `cmd/tools/*` 入口集中注入，禁止直接 new 仓储；与 Plan 200 的模块化单体原则一致。
+2. **sqlc + Atlas 守卫**：`make sqlc-generate`、`atlas migrate diff` 为强制步骤，需在 `logs/plan401/sqlc-generate.log`、`logs/plan401/atlas-diff.log` 留证；CI 若出现漂移必须阻断，符合 Plan 201 的差异项要求。
+3. **Docker-first 测试**：`make test-db`/`scripts/run-integration-tests.sh` 必须在 Docker Compose 中执行 Goose Up → Go Integration Tests → Goose Down；验收需附 `logs/plan401/test-db/*.log`，与 Plan 200 的“迁移即真源 + Docker 环境”约束一致。
+4. **事务性发件箱 + 持久事件总线**：快照刷新、维度快照、时光机作业全部通过 Outbox 事件驱动，并使用持久 EventBus Adapter（Redis/Faktory/Asynq），不得依赖内存队列；对齐 201 中“可靠异步”的要求。
+5. **PBAC 与命名守卫**：Plan 252/259 的策略源需纳入 Schema Registry 与 Manifest；`scripts/quality/auth-permission-contract-validator.js`、`scripts/quality/architecture-validator.js` 必须验证仓库不存在 `_from/_to` 命名或硬编码 scope。
+6. **质量流水线**：CI 需执行 `make lint`, `make fmt`, `npm run lint`, `npm run quality:preflight`、`make security` 等守卫，并将日志写入 `logs/plan401/quality/*.log`；违反任一守卫视为不符合 200/201 基线。
+
+满足上述守卫后，Plan 401 的实施才视为与 Plan 200/201/400/402 完整对齐。
 
 #### **引用的著作**
 

--- a/docs/development-plans/402-capability-contracts.md
+++ b/docs/development-plans/402-capability-contracts.md
@@ -1,0 +1,55 @@
+# 402 · Standard Object 能力契约目录
+
+**状态**：基线草案（随 Plan 400/402 迭代更新）  
+**唯一事实来源**：`docs/development-plans/400-standard-object-model-plan.md`、`docs/development-plans/402-standard-object-single-source-plan.md`、`docs/api/openapi.yaml`、`docs/api/schema.graphql`、`internal/standardobject/**`、`database/migrations/20251201090000_create_standard_objects.sql`  
+**日志规范**：`logs/plan402/capability/*.log`（记录每次联邦/模块接入或矩阵更新的 CLI 输出/校验结果）
+
+> 说明：本文件用于集中记录组织（organization）、职位（position）及未来 HR 模块在复用 Standard Object 模型时的“Federate 能力契约”。任何模块新增/调整 SOM 能力都必须同步此表，并在 CI/本地通过 `node scripts/quality/architecture-validator.js --rule capabilityContracts` 校验。  
+> 若需扩展字段/能力，请优先修改 Plan 400/402 以及对应迁移/端口，再更新本文；禁止直接引用第二事实来源。
+
+---
+
+## 1. 术语与证据
+
+- **能力（Capability）**：模块对外暴露或依赖的 Standard Object 能力，例如 `ORG_HIERARCHY` 链接写入、`standard_object.*` 事件、Schema Registry 读写、Temporal 页面渲染 slot。
+- **Federate**：与 SOM 交互的逻辑模块，通常对应 `internal/<module>` 下的命令/查询服务、前端入口或工具脚本。
+- **证据路径**：
+  - `logs/plan402/capability/*.log`：记录 `standardobject-migrator`、`standardobject-validator`、Feature Flag 切换与能力巡检的输出。
+  - `logs/plan400/schema/*.log`：Schema Registry DEC/OCL 缺失检查。
+  - `logs/plan400/snapshots/*.log`：快照/闭包刷新任务。
+  - `frontend/tests/e2e/standard-object-*.spec.ts`：前端视点证据。
+
+---
+
+## 2. 能力矩阵（必填项）
+
+| 模块 (Federate) | 提供能力 | 依赖能力 | 视点覆盖 | 证据/日志 |
+|-----------------|-----------|-----------|-----------|-----------|
+| **Organization Federate**<br/>`internal/organization/**` + REST/GraphQL | - 写入 `standard_objects`/`standard_object_versions`（ObjectKernel + TemporalVersion）<br/>- 维护 `ORG_HIERARCHY` 链接 & 快照<br/>- 广播 `standard_object.*` outbox 事件（命令服务 9090）<br/>- 提供 Schema Registry 条目 `objectType=ORGANIZATION_UNIT`，绑定 DEC/OCL | - SOM Core API (`internal/standardobject/api.go`)<br/>- Schema Registry 哈希校验<br/>- PBAC scope (`standardObject.organization.*`)<br/>- `cmd/tools/standardobject-snapshot-refresh` | **结构视点**：组织层级 + DEC<br/>**运行视点**：状态机、outbox、快照<br/>**观察视点**：`logs/plan400/ui` Playwright 证据<br/>**协作视点**：Manifest/Slot、PBAC | `logs/plan402/capability/org-federate.log`（迁移+巡检）<br/>`logs/plan400/schema/*.log`（DEC/OCL）<br/>`logs/plan400/snapshots/*.log`（刷新） |
+| **Position Federate**<br/>`internal/position/**` + 前端 Position 详情 | - 写入/读取 `POSITION_BELONGS_TO_ORG` 链接<br/>- 维护职位版本 payload (`objectType=POSITION_ROLE`)<br/>- 消费 `standard_object.*` 事件（组织变更触发校验）<br/>- 通过 `standardObjectAdapter` 渲染 Temporal 页面 | - Organization Federate 事件 / 链接<br/>- SOM Core API、Schema Registry<br/>- Manifest Slot（`temporal:position:*`）<br/>- PBAC scope (`standardObject.position.*`) | **结构视点**：职位->组织依赖<br/>**运行视点**：双写/校验、事件消费<br/>**观察视点**：Playwright `position-*.spec.ts`<br/>**协作视点**：Manifest、PBAC | `logs/plan402/capability/position-federate.log`（双写/校验）<br/>`frontend/tests/e2e/standard-object-lifecycle.spec.ts`<br/>`logs/plan400/schema/*.log` |
+| **Shared Federate**（Temporal UI/工具链）<br/>`frontend/src/features/temporal/**`、`scripts/generate-*` | - 提供 `standardObjectAdapter`、字段/表单生成（OpenAPI/GraphQL）<br/>- 输出 Manifest/Slot 注册及 OBS 事件模板<br/>- 汇总 Schema Registry/DEC 清单 & `schema-registry.json` | - GraphQL 查询 (`cmd/hrms-server/query`) + 快照 MV<br/>- Schema Registry 哈希、`standard_object_translations`<br/>- Capability logs (`logs/plan400/ui/*.log`) | **结构视点**：表单字段与 DEC 映射<br/>**运行视点**：GraphQL 查询 + 快照来源<br/>**观察视点**：OBS `[OBS] standardObject.*`、Playwright<br/>**协作视点**：Manifest/Slot、PBAC 列表 | `logs/plan400/manifest/*.log`（生成器运行）<br/>`logs/plan402/capability/shared-federate.log`（CLI 输出）<br/>`logs/plan400/ui/*.log`（Playwright/OBS） |
+
+> 维护规则：
+> 1. `提供能力`/`依赖能力`/`视点覆盖`/`证据` 任一项变更都需在 PR 中同步更新此表，并附最新日志。
+> 2. 任一 Federate 暂停/下线时，需在“备注”列说明替代机制与回收计划，然后在 `docs/archive/development-plans/` 归档旧版本。
+> 3. 新增 Federate 需至少覆盖结构+运行两个视点，并提供对应日志路径；否则视为不合规。
+
+---
+
+## 3. 维护与巡检流程
+
+1. **更新矩阵**：当组织/职位或新模块调整 SOM 功能时，先更新 Plan 400/402 -> 迁移/端口/前端 -> 最后回到本文件补表。
+2. **运行巡检脚本**：执行 `node scripts/quality/architecture-validator.js --rule capabilityContracts`，在 `logs/plan402/capability/<date>-matrix-check.log` 写入结果。
+3. **提交证据**：将 `logs/plan402/capability/*.log`、`logs/plan400/schema/*.log`、`logs/plan400/snapshots/*.log` 等链接写入 PR，并确保 `reports/architecture/architecture-validation.json` 通过守卫。
+
+---
+
+## 4. 未来迭代占位
+
+- **Workforce/Contract Federate**：待 Plan 4xx 立项后补充能力条目（默认继承 Shared Federate 的 Schema/Manifest 约束）。  
+- **数据仓库/审计输出**：若后续将 SOM 事件写入数据仓库或审计总线，需要新增 Federate，并在此表说明消费链路与证据。  
+- **第三方/跨域模块**：引入外部系统前，必须先在本表登记能力及回滚策略，再进入集成阶段。
+
+---
+
+如对本目录有更新需求，请在 `docs/development-plans/00-README.md` 登记并引用 Plan 400/402/403 的最新版本，确保事实来源一致。

--- a/docs/development-plans/402-standard-object-single-source-plan.md
+++ b/docs/development-plans/402-standard-object-single-source-plan.md
@@ -70,9 +70,9 @@
 | `sort_order` | `standard_object_links.attributes.sortOrder` | 父子顺序与 link 绑定。 |
 | `profile`, `metadata` | `standard_object_versions.payload` | JSON 配置与扩展属性随版本变化，集中进 payload JSONB。 |
 | `created_at`, `updated_at` | `standard_objects.created_at/updated_at` | 对象创建与最近对象级更新时间，Plan 400 要求存放在对象表。 |
-| `effective_date` | `standard_object_versions.effective_from` | DATE 语义映射到版本的生效开始时间。 |
-| `end_date` | `standard_object_versions.effective_to` | DATE 语义映射到版本的生效结束时间。 |
-| `effective_from`, `effective_to`（timestamp） | `standard_object_versions.effective_from/to` | 若现有记录提供更细粒度时间，直接覆盖 DATE 版本。 |
+| `effective_date` | `standard_object_versions.effective_date` | 版本的生效日期；在 SOM 中统一命名为 `effective_date`（DATE）。 |
+| `end_date` | `standard_object_versions.end_date` | 版本的结束日期；与 `effective_date` 一致保持统一命名。 |
+| `effective_from`, `effective_to`（timestamp） | – | 不再引入 `_from/_to` 命名，如需更细粒度的时间点，可追加独立字段而不是混用命名。 |
 | `change_reason`, `operation_type` | `standard_object_versions.audit` | 作为 `audit.changeReason`、`audit.operation` 保存，供版本追溯。 |
 | `is_current` | `standard_object_versions.is_current` | 迁移到版本表，配合 Plan 400 状态规则确定活跃版本。 |
 | `deleted_at`, `deleted_by`, `deletion_reason` | `standard_object_versions.audit` | 视为终止原因，仍属于版本层审计信息。 |
@@ -81,6 +81,21 @@
 | `changed_by`, `approved_by` | `standard_object_versions.audit` | 审批链条属于版本审计。 |
 
 > 备注：`code_path/name_path` 等派生列迁移后由 `standard_object_links` + `standard_object_hierarchy_snapshots` 重建；`organization_units` 表本身不再持久化这些冗余字段，确保唯一事实来源集中在 SOM 三表。
+
+> 语义锚点要求：迁移规格需为上述每个字段提供 ISO 11179 Data Element Concept（DEC）映射、来源链接与语义版本，确保 Schema Registry/生成脚本/前端提示引用同一 ID；缺失的 DEC 必须在 402A 立项阶段补齐或记录风险并给出回收期限。
+
+#### 4.1.1 标准对象模型应具备的通用维度（与 Plan 400 对齐）
+为避免“映射只关注列迁移而忽视元模型完整性”，本计划沿用 Plan 400 的标准对象元模型，将以下维度视为强制要求：
+
+- **ObjectKernel（对象内核）**：由 `standard_objects` 承载，包含 `objectType`、`code`、`displayName`、`status`、`tenantCode`、`labels`、`schemaVersion`、`dataClassification`、`retentionPolicy`、`createdBy/createdAt/updatedAt` 等字段；所有对象级元数据、标签、权限/保留策略都应在此维度维护。
+- **TemporalVersion（时态版本）**：由 `standard_object_versions` 表表示，字段至少包括 `versionCode`、`effectiveDate`、`endDate`、`payload`（JSONB）、`isCurrent`、`audit`、`checksum`、`createdAt/updatedAt`。任何业务属性或审计信息都必须放入 payload/audit，确保“变更 = 新版本”。
+- **LifecyclePolicy（生命周期策略）**：对象类型需绑定状态机（`DRAFT→READY→ACTIVE→SUSPENDED→RETIRED`）和校验策略，既有字段（如 `status`、`isCurrent`、`effectiveDate`）必须能驱动状态变更；策略定义在 `internal/standardobject/policy/*`，并由命令服务注入。
+- **Link（关系/层级）**：`standard_object_links` 负责父子、归属、挂载等关系，字段包含 `linkType`、`source_object_id`、`target_object_id`、`attributes`（储存 sortOrder、hierarchyDepth、path 缓存等）。任何层级/跨模块引用都需通过 Link 实现，禁止在版本表冗余 parent_code。
+- **EventEnvelope（事件信封）**：命令服务写 `standard_object.*` outbox 事件，payload 至少包含 `{objectType, code, versionCode?, status?, occurredAt}`；Plan 400/402 的迁移、双写、快照刷新都以该事件为触发源。
+- **读模型/快照**：由 `standard_object_hierarchy_snapshots`、`*_mv` 物化视图、`cmd/tools/standardobject-snapshot-refresh` 提供，确保查询层可以按 `asOfDate`/`tenant` 快速读取层级数据，并与事件日志、Plan 401 方案一致。
+- **Schema Registry & 扩展维度**：统一维护 `standard_object_schemas`（payload schema/哈希）、`standard_object_translations`（多语言）、`standard_object_attachments`（外部文档）、`standard_object_metrics`（可观测性/刷新指标），与 Plan 300/401/272 的治理要求对齐。
+
+以上维度是标准对象模型的“最小集合”。402 的映射、迁移、双写、前端接入都必须证明这些维度被完整覆盖，并在各阶段交付物/日志中给出证据，否则视为与 Plan 400 不一致。
 
 ### 4.2 SOM 三表字段目标清单
 
@@ -95,12 +110,13 @@
 |  | `display_name text` | 当前展示名称，镜像自最新版本 payload，便于列表查询 |
 |  | `status text` | 生命周期状态（Plan 400 §4.2：`DRAFT/READY/ACTIVE/SUSPENDED/RETIRED`） |
 |  | `labels jsonb` | 对象级标签/分类（如 `unitType`、`region`） |
-|  | `schema_version text` (可选) | payload schema 版本标记，辅助校验器 |
+|  | `schema_version text` | payload schema 版本标记，对应 schema registry 条目 |
+|  | `data_classification text` / `retention_policy text` | 数据主权/保留策略，用于审计与 PBAC 扩展 |
 |  | `created_by uuid` / `created_at timestamptz` / `updated_at timestamptz` | 对象级审计字段 |
 | `standard_object_versions` | `id uuid PK` | 单个版本记录 ID |
 |  | `object_id uuid FK` | 指向 `standard_objects.id` |
 |  | `version_code text` | 版本编号/外部 ID（可映射旧 `record_id+effective_date`） |
-|  | `effective_from timestamptz` / `effective_to timestamptz` | 版本生效区间；日期粒度可在视图层转化 |
+|  | `effective_date date` / `end_date date` | 版本生效区间（DATE）；如未来需要秒级精度，可新增扩展列但命名仍沿用 `*_date` |
 |  | `is_current boolean` | 标识活跃版本，配合生命周期校验 |
 |  | `payload jsonb` | 版本化字段载体（名称、描述、profile/metadata、扩展属性等） |
 |  | `audit jsonb` | 审计轨迹：`changeReason/operation/changedBy/approvedBy/operatedBy/deleted*/suspended*` 等 |
@@ -109,36 +125,47 @@
 | `standard_object_links` | `id uuid PK` | 链接记录 ID |
 |  | `source_object_id uuid FK` / `target_object_id uuid FK` | 父子/起止对象 ID |
 |  | `link_type text` | 关系类型（`ORG_HIERARCHY`、`POSITION_BELONGS_TO_ORG` 等），发行方需维护枚举表 |
-|  | `attributes jsonb` | 链接附加信息（`sortOrder`、`level`、`hierarchyDepth`、`codePath/namePath` 缓存、`isPrimary`、可选 `effectiveFrom/To` 等） |
+|  | `attributes jsonb` | 链接附加信息（`sortOrder`、`level`、`hierarchyDepth`、`codePath/namePath` 缓存、`isPrimary`、可选 `effectiveDate/endDate` 等） |
 |  | `tenant_code text` | 保持多租隔离（可从 source 继承） |
 |  | `created_by uuid` / `created_at timestamptz` / `updated_at timestamptz` / `updated_by uuid` | 链路级审计 |
 
-> 索引/约束：`standard_object_versions` 至少需要 `(object_id, version_code)` 与 `(object_id, effective_from)` 唯一索引；`is_current` 过滤索引用于快查；`standard_object_links` 需 `UNIQUE (source_object_id, target_object_id, link_type)` 并启用外键级联。若业务需要携带 schema hash/outbox 关联，可在 Phase B 追加列，但此表为 Plan 400/402 的最小字段集合。
+> 索引/约束：`standard_object_versions` 至少需要 `(object_id, version_code)` 与 `(object_id, effective_date)` 唯一索引；`is_current` 过滤索引用于快查；`standard_object_links` 需 `UNIQUE (source_object_id, target_object_id, link_type)` 并启用外键级联。若业务需要携带 schema hash/outbox 关联，可在 Phase B 追加列，但此表为 Plan 400/402 的最小字段集合。
+
+> **命名唯一性原则**：SOM 及所有过渡视图/仓储仅允许 `effective_date/end_date` 字段，严禁再次引入 `effective_from/effective_to` 或类似变体；若未来需要更精细的时间点，需通过新增扩展列并保留 `*_date` 命名。
+
+> 补充通用维度：SOM 需同时覆盖 schema registry、翻译、附件与可观测性元数据。计划在阶段 B 建立 `standard_object_schemas`（记录 JSON Schema/哈希/发布策略）、`standard_object_translations`（`locale`, `display_name`, `description` 等多语言字段）、`standard_object_attachments`（外部文档/批复，含存储 URI、类别、合规标签）以及 `standard_object_metrics`（累计观察指标，用于快照/刷新监控）等扩展表，并通过 Feature Flag 渐进启用。
+
+> OCL 守卫：按照 Plan 403 建议，`standard_object_schemas` 每条记录需携带 `oclGuards`（不变量/前置/后置条件）。402 计划要在 migrator、validator、命令/查询服务中复用统一 OCL 引擎，确保字段迁移与版本状态机符合组合约束，否则直接阻断写入。
+
+### 4.3 模块化联邦与能力契约
+参考 403 文档的 Modular Federation Pattern，Plan 402 在迁移期必须维持“能力契约”目录，描述每个模块提供/消费的 Standard Object 特性，并在子计划验收时复核：
+
+| 模块 | 提供能力 | 依赖能力 | 约束与验证 |
+|------|----------|----------|------------|
+| Organization Federate | `ORG_HIERARCHY` link、`organization.unit` payload schema、`standard_object.*` 事件 | SOM Kernel、Link、Schema Registry | OCL：组织节点 `labels.unitType` 必须存在；DEC：`tenantCode` 与 `links.tenantCode` 相同 |
+| Position Federate | `position.role` payload、`POSITION_BELONGS_TO_ORG` link | SOM Kernel、Organization Federate 事件 | OCL：职位版本必须引用 ACTIVE 的组织；DEC：`positionProfile` 引用共享 DEC |
+| Shared Federate（未来 workforce/contract） | `standardObjectAdapter`、Schema Registry 读写、Manifest slots | Kernel/Version/Link/Events | OCL：`effectiveDate ≤ endDate`；视点：结构+运行+观察 |
+
+能力契约文档存放 `docs/development-plans/402-capability-contracts.md`（由本计划输出），并在 402B 之后纳入 `scripts/quality/architecture-validator.js` 检查，严禁新增“单表例外”。
 
 ---
 
 ## 5. 执行计划（建议 3 阶段）
 
 ### 阶段 A · 契约与映射（1 Sprint）
-- 任务
-  1. 编写《Standard Object 映射规格》：列出 `organization_units` → `standard_objects`/`standard_object_versions`/`standard_object_links` 字段映射、触发器替代方案、payload schema 设计。
-  2. 补充 `docs/api/openapi.yaml`、`docs/api/schema.graphql` 中与 SOM 相关的实体/枚举，明确状态机、版本/链接字段（与 Plan 400 同步）。
-  3. 设计临时兼容视图（如 `vw_organization_units`) 及 Port 适配，确保迁移期命令/查询代码可并行验证。
-- 交付：映射规格、API 契约 diff、视图/Port 设计草案。
+- 目标与交付详见 [402A · SOM 映射与契约准备](./402A-standard-object-mapping-and-contracts.md)。该阶段聚焦字段映射、OpenAPI/GraphQL 契约与兼容视图/Port 设计，并输出 DEC/OCL hazard list 及 `logs/plan402/mapping/*` 证据。
 
 ### 阶段 B · 数据层改造（1-2 Sprint）
-- 任务
-  1. 实施 `standard_objects*` 迁移（`atlas`/`goose`），生成 sqlc 仓储，放置于 `internal/standardobject/repository/sqlc`。
-  2. 在命令/查询服务中注入 `ObjectService`，组织/职位模块通过 Port 操作 SOM，保留 feature flag `STANDARD_OBJECTS_ENABLED` 以支撑回滚。
-  3. 构建双写/校验脚本：`cmd/tools/standardobject-migrator`（一次性导入）与 `cmd/tools/standardobject-validator`（比对记录与层级）。
-- 交付：迁移 SQL、sqlc 代码、Go/TS 适配、双写脚本与运行日志（`logs/plan402/migration/*.log`）。
+- 详见 [402B · SOM Schema 与工具链](./402B-som-schema-and-tooling.md)。负责创建 `standard_objects*` 迁移、sqlc 仓储、migrator/validator/snapshot-refresh 工具，以及 Schema Registry/扩展表与日志样例。
 
-### 阶段 C · 切换与收敛（1 Sprint）
-- 任务
-  1. 关闭旧仓储写路径，只读 `organization_units` 视图；验证 outbox 事件、快照/闭包刷新均引用 SOM。
-  2. 更新前端 Temporal 页面至 `standardObjectAdapter`（复用 Plan 400 设计），清理组织/职位特有的冗余表单逻辑。
-  3. 执行 `make test`、`make test-db`、`npm run test`、`npm run test:e2e` 及 `scripts/quality/*`，在 `logs/plan402/` 留存证据；若出现重大缺陷，按照回滚流程重新启用旧表并 Goose Down。
-- 交付：切换报告、测试证据、回滚记录（若触发）。
+### 阶段 C · 服务接入与双写（1-2 Sprint）
+- 详见 [402C · 服务接入与双写](./402C-service-integration-and-double-write.md)。主要任务包括命令/查询服务接入、Feature Flag、双写/校验、outbox/快照、Manifest/Slot 与能力契约巡检。
+
+### 阶段 D · 切换与回收（1 Sprint）
+- 详见 [402D · 切换与回收](./402D-cutover-and-recovery.md)。该阶段执行最终迁移、关闭旧表写入、完成前端/查询适配、跑门禁与回滚演练，并生成切换 Runbook。
+
+### 阶段 E · 收敛与治理（可选）
+- 详见 [402E · 收敛与治理](./402E-convergence-and-governance.md)。集中处理旧表/代码清理、文档/索引更新、监控/OBS 完善与未来模块接入指南。
 
 ---
 
@@ -148,234 +175,22 @@
 
 | 子计划 | 范围与任务 | 关键交付物 / 依赖 |
 |--------|------------|-------------------|
-| **402A – SOM 映射与契约准备** | 1) 完成 `organization_units` → SOM 三表字段映射（含本文 4.1/4.2 内容落地为《Standard Object 映射规格》）；2) 设计临时兼容视图/Port（`vw_organization_units` + `internal/standardobject/adapter` 草案）；3) 在 `docs/api/openapi.yaml`、`docs/api/schema.graphql` 中补齐 Standard Object 实体、枚举与权限 scopes。 | 映射规格文档、API diff、Port/视图设计。依赖：Plan 400 契约、Plan 201 sqlc 规范。 |
-| **402B – SOM Schema & 工具链** | 1) 通过 Atlas/Goose 创建 `standard_objects*` 迁移（含 Up/Down）；2) 更新 `sqlc.yaml` 并生成 `internal/standardobject/repository/sqlc`；3) 实作 `cmd/tools/standardobject-migrator`、`cmd/tools/standardobject-validator` 验证脚本；4) 建立 `logs/plan402/migration/*.log` 证据规范。 | 数据库迁移脚本、sqlc 生成物、迁移/校验工具。依赖：402A 文档输出、Atlas/Goose 工具、Plan 215/255 Guards。 |
-| **402C – 服务接入与双写** | 1) 命令/查询服务注入 `ObjectService` Port，组织/职位仓储切换至 SOM，并保留 `STANDARD_OBJECTS_ENABLED` feature flag；2) 构建双写链路（旧表 + SOM）与自动校验；3) 补齐 outbox 事件、快照/闭包刷新逻辑对接新表。 | Go/TS 服务改造 diff、feature flag 配置、双写/校验运行日志。依赖：402B schema、Plan 401 快照方案、Plan 252/259 权限守卫。 |
-| **402D – 切换与回收** | 1) 执行一次性迁移（关闭旧表写入，视图只读）；2) 更新前端 Temporal 页面接入 `standardObjectAdapter` 并完成 Playwright 证据；3) 完整跑门禁（`make test*`、`npm run test*`、`scripts/quality/*`）并在 `logs/plan402/`、`reports/` 存证；4) 定义 Goose Down / 数据回滚脚本并实测。 | 切换报告、回滚脚本、前端适配 diff、测试日志。依赖：402C 双写稳定、Plan 222/Plan 255 门禁。 |
-| **402E – 收敛与治理**（可选） | 1) 清理 `organization_units` 相关代码/触发器，仅保留兼容视图或最终删除；2) 将 SOM 纳入 `docs/reference/01-DEVELOPER-QUICK-REFERENCE.md`、`docs/development-plans/400/401` 的唯一事实来源；3) 监控/指标/OBS 事件对接；4) 规划未来模块（positions 之后的 payroll/workforce）如何直接消费 SOM。 | 清理脚本、文档更新、OBS/监控布置。依赖：402D 验收通过、Plan 400/401 更新、Plan 215 文档治理。 |
+| [**402A – SOM 映射与契约准备**](./402A-standard-object-mapping-and-contracts.md) | 1) 完成 `organization_units` → SOM 三表字段映射（含 DEC/OCL 记录）；2) 设计兼容视图/Port；3) 补齐 OpenAPI/GraphQL 契约与权限 scope。 | 映射规格、API diff、Port/视图设计。依赖：Plan 400 契约、Plan 201 sqlc 规范。 |
+| [**402B – SOM Schema & 工具链**](./402B-som-schema-and-tooling.md) | 1) 创建 `standard_objects*` 迁移；2) 更新 `sqlc.yaml` 与仓储；3) 实作 migrator/validator/snapshot-refresh 工具；4) 建立日志规范。 | 迁移脚本、sqlc 生成物、迁移/校验工具与日志。依赖：402A、Atlas/Goose、Plan 215/255。 |
+| [**402C – 服务接入与双写**](./402C-service-integration-and-double-write.md) | 1) 命令/查询服务注入 Port 并保留 Feature Flag；2) 构建双写 + 自动校验；3) 对接 outbox、快照、Manifest/Slot。 | Go/TS 改造 diff、Flag/双写/校验日志。依赖：402B、Plan 401、Plan 252/259。 |
+| [**402D – 切换与回收**](./402D-cutover-and-recovery.md) | 1) 执行一次性迁移并关闭旧写入；2) 更新前端/查询；3) 跑门禁与回滚演练；4) 输出 Runbook。 | 切换报告、回滚脚本、测试日志。依赖：402C、Plan 222/255。 |
+| [**402E – 收敛与治理**](./402E-convergence-and-governance.md)（可选） | 1) 清理旧表/代码；2) 更新文档索引；3) 完善监控/OBS；4) 输出 SOM 接入指南。 | 清理脚本、文档更新、OBS/监控布置。依赖：402D、Plan 400/401、Plan 215。 |
 
 > 行动顺序：402A（立项确认）→ 402B（schema/tooling）→ 402C（接入双写）→ 402D（切换验收）→ 402E（善后治理）。在发布日期前，任一子计划未完成不得进入下一子计划，以确保“资源唯一性”。
 
 ---
 
-### 子计划 402A · SOM 映射与契约准备
-
-状态：拟立项（需调研佐证）  
-依赖：Plan 400 契约、Plan 201 sqlc 规范、`docs/api/*` 现有定义  
-覆盖范围：组织/职位命令与查询模块、Docs/API 契约、临时 Port/视图设计
-
-**目标**
-1. 形成《Standard Object 映射规格》，把本节 4.1/4.2 的字段映射扩展为可执行规范，明确字段来源、转换规则、回滚策略。
-2. 在 API 契约层引入 Standard Object 实体、枚举与权限 scope（REST + GraphQL），确保“先契约后实现”。
-3. 设计临时兼容层（视图 + Port Adapter），使 `internal/organization`/`internal/position` 能在不立即改写仓储的情况下读取 SOM 结构，为双写做准备。
-
-**工作项**
-- **A1 · 文档固化**：  
-  - 将本计划 4.1/4.2 内容转化为《Standard Object 映射规格》，含字段映射、默认值、触发器替代方案。  
-  - 输出迁移矩阵（`organization_units` → SOM 三表），列出每列处理方式、验证 SQL、潜在风险。  
-- **A2 · 契约补全**：  
-  - 更新 `docs/api/openapi.yaml`，新增 `/standard-objects/{objectType}` REST 端点、状态机、scope（参考 Plan 400 §4.4）。  
-  - 更新 `docs/api/schema.graphql`，加入 `StandardObject`, `StandardObjectVersion`, `StandardObjectLink` 类型、输入输出结构。  
-  - 同步 `docs/reference/05-CI-LOCAL-AUTOMATION-GUIDE.md`/Plan 252/259 索引，声明新的权限守卫来源。  
-- **A3 · 兼容设计**：  
-  - 设计 `vw_organization_units`/`vw_position_units` 视图，用 SOM 三表模拟旧表结构，说明列映射、索引策略。  
-  - 起草 `internal/standardobject/adapter` 接口定义（命令/查询所需 Port、DTO、错误模型），并描述与现有仓储的注入方式。  
-  - 定义 Feature Flag 与回滚策略文档，为 402C 双写做铺垫。
-
-**交付物**
-- 《Standard Object 映射规格》（含 SQL/脚本示例、校验 checklist）。
-- OpenAPI & GraphQL diff（带守卫脚本输出）以及权限 scope 更新说明。
-- 视图/Port 设计草案（UML 或代码 skeleton）、Feature Flag/回滚策略文档。
-
-**验收标准 & 证据**
-- 映射规格通过架构组评审，登记于 `docs/development-plans/00-README.md`，并在 `logs/plan402/mapping/*.log` 留存评审记录。
-- OpenAPI/GraphQL 变更通过 `scripts/quality/architecture-validator.js`、`node scripts/quality/contract-checker.js`，无命名/字段偏差。
-- 视图/Port 设计在 `internal/standardobject` skeleton 中可编译（编译守卫通过），并附 `make sqlc-generate` 预检日志。
-
-**风险**
-- 契约变更影响现有客户端 → 需与 Plan 222 前端负责人同步时间表，提前暴露 schema diff。
-- 视图方案可能导致性能回退 → 需在 A3 输出基准 SQL 及 explain plan，对大 tenant（≥10k 组织）给出估算。
-
-完成 402A 后方可启动 402B（迁移与工具链），否则禁止对数据库 schema/仓储进行 SOM 相关改动。
-
----
-
-### 子计划 402B · SOM Schema 与工具链
-
-状态：待启动（依赖 402A 输出）  
-依赖：402A 映射规格 & 契约、Atlas/Goose 工具链、Plan 215/255 门禁  
-覆盖范围：数据库迁移、sqlc 配置、迁移/校验工具、日志规范
-
-**目标**
-1. 在数据库层创建 `standard_objects`/`standard_object_versions`/`standard_object_links` 三表（含索引、约束、触发器），并提供 Up/Down 迁移脚本，符合 Plan 400 4.3 要求。
-2. 更新 `sqlc.yaml` 与相关包结构，生成 `internal/standardobject/repository/sqlc`，为后续服务接入提供类型安全的仓储接口。
-3. 交付一次性迁移工具（migrator）与对账工具（validator），用于从 `organization_units` 等旧表导入 SOM，并验证数据一致性，同时制定日志/证据规范。
-
-**工作项**
-- **B1 · 迁移脚本**：  
-  - 使用 Atlas/Goose 创建 `20251201090000_create_standard_objects.sql`（Up/Down），包含三表、索引、约束、触发器（如 `is_current` 自动控制、链接级联）。  
-  - 在同批次脚本中新增 `standard_object_hierarchy_snapshots` 等后续依赖的骨架（可留空，但需注释）。  
-  - 更新 `database/migrations/README.md` 记录，并在 `logs/plan402/migration/*.log` 保存 `atlas diff`/`goose up` 运行日志。  
-- **B2 · sqlc & 包结构**：  
-  - 调整 `sqlc.yaml`，新增 SOM schema 相关查询（CRUD、列表、链接维护），生成文件放置 `internal/standardobject/repository/sqlc`。  
-  - 在 `internal/standardobject/domain` 目录创建实体/DTO 定义，并提供 `ObjectRepository` 接口供后续服务依赖。  
-  - 更新 `make sqlc-generate` pipeline，确保 CI/本地均可生成；记录运行日志。  
-- **B3 · 迁移/校验工具**：  
-  - `cmd/tools/standardobject-migrator`：读取旧 `organization_units`（以及 positions 相关表），写入新表；支持 dry-run、并行批处理、失败回滚；日志落盘 `logs/plan402/migration/migrator-*.log`。  
-  - `cmd/tools/standardobject-validator`：对比旧表与 SOM 数据（计数、哈希、层级一致性），输出 JSON 报告至 `logs/plan402/validator/*.json`。  
-  - 定义工具使用手册和回滚流程（若 migrator 失败如何清理数据等）。  
-
-**交付物**
-- `database/migrations/20251201090000_create_standard_objects.sql`（含 Down）、Atlas diff 记录。
-- 更新后的 `sqlc.yaml`、生成的 Go 代码、`internal/standardobject` 包 Skeleton。
-- migrator/validator 源码、编译产物、使用说明；`logs/plan402/migration/*.log` / `logs/plan402/validator/*.json` 证据样例。
-
-**验收标准**
-- `make db-migrate-all`、`make db-rollback-last` 针对新脚本执行通过（含 Docker Compose 环境），并在日志目录留存输出。
-- `make sqlc-generate` 在本地和 CI 均可无误生成，`git status` 清洁；Plan 201 差异项脚本通过。
-- migrator/validator 至少在沙盒数据集上跑通一遍，落盘报告，与映射规格一致；若发现数据差异，能产出可执行的对账结论。
-
-**风险**
-- **Schema 约束冲突**：旧数据可能违反 SOM 约束（如缺少 `version_code`）。缓解：在 migrator 中提供修复策略（自动生成 versionCode、补齐缺失字段），并记录 hazard list。  
-- **生成物不一致**：sqlc 版本/配置不一致导致不同开发者生成不同代码。缓解：锁定 sqlc 版本（Go toolchain/gobin）并在 `Makefile` 强制校验。  
-- **工具运行性能**：迁移/校验涉及大数据量，可能耗时或锁表。缓解：使用分批/分页策略，默认 read-only 模式，提供限速参数和监控（写入 `logs/plan402/migration/*.log`）。  
-
-仅在 402B 验收通过后，方可进入 402C（接入与双写）；否则禁止服务层引用 SOM 仓储，以免出现“双事实来源”。
-
----
-
-### 子计划 402C · 服务接入与双写
-
-状态：待启动（依赖 402A/402B 输出）  
-依赖：402A 映射 + 契约、402B Schema & 工具链、Plan 401 快照/闭包方案、Plan 252/259 权限守卫  
-覆盖范围：组织/职位命令服务、查询服务（GraphQL）、Feature Flag、Outbox/快照刷新
-
-**目标**
-1. 让组织/职位命令与查询服务通过 `ObjectService` Port 操作 SOM，保留受控 Feature Flag (`STANDARD_OBJECTS_ENABLED`) 和回滚策略。
-2. 构建双写机制：写入操作同时更新 SOM 与旧表（或旧表只读、根据策略决定），并提供自动校验与告警，确保数据一致。
-3. 适配 outbox 事件、闭包/快照刷新、查询缓存，使读取路径能在双写期间优先消费 SOM（或通过视图兼容）。
-
-**工作项**
-- **C1 · Port 接入**：  
-  - 在命令服务（`cmd/hrms-server/command/internal/organization` 等）注入 `ObjectCommandService`，使用 402B 的 sqlc 仓储；保留旧仓储以便回滚。  
-  - 查询服务（GraphQL）通过 `internal/standardobject/query` 读取 SOM（或视图），补齐 DTO/Resolver 层。  
-  - `STANDARD_OBJECTS_ENABLED` Feature Flag：通过环境变量/配置文件控制，明确默认值与回滚步骤。  
-- **C2 · 双写与校验**：  
-  - 写路径：当 Flag 开启时，命令服务写 SOM + 旧表（或通过视图写 SOM），并记录双写日志（`logs/plan402/doublewrite/*.log`）。  
-  - 读路径：优先读 SOM；若 Flag 关闭则回退旧表。  
-  - 校验：集成 `standardobject-validator` 或新增定时任务，比对双写结果，异常时触发告警并自动切回旧表。  
-- **C3 · Outbox/快照接入**：  
-  - outbox dispatcher 写入 `standard_object.*` 事件（Plan 400 4.4），并更新消费方（快照刷新、下游模块）。  
-  - 快照/闭包工具（Plan 401）在 SOM 写操作后触发刷新；保留日志 `logs/plan402/snapshots/*.log`。  
-  - 更新缓存/GraphQL 数据加载器，确保 `standard_object_links` 能驱动层级查询。  
-
-**交付物**
-- 命令/查询服务改造 diff（Go/TS），含 Feature Flag 配置、依赖注入代码、Port/Adapter 实现。
-- 双写/校验运行日志、回滚脚本说明（如何关闭 Flag、清理未完成数据）。
-- Outbox 事件/快照刷新改造文档与证据（日志、Playbook）。
-
-**验收标准**
-- 在 `STANDARD_OBJECTS_ENABLED=true/false` 两种模式下，`make test`、`make test-db`、`npm run test` 全量通过；`logs/plan402/doublewrite/*.log` 记录双写成功/失败情况。
-- 双写期间 `standardobject-validator` 无差异（或差异清单在允许范围并有回滚策略）；异常触发时可在 5 分钟内自动切回旧表。
-- Outbox/快照链路跑通，Plan 401/Plan 250 相关脚本通过（GraphQL/REST 读 SOM 符合契约，快照刷新日志齐备）。
-
-**风险**
-- **双写一致性**：复杂事务可能导致 SOM 与旧表不一致。缓解：采用事务内双写 + 失败回滚、校验脚本实时监控；必要时短期只读旧表。  
-- **性能退化**：双写/校验增加负载。缓解：引入批量写/异步校验选项，监控关键指标（Postgres TPS、延迟）。  
-- **Flag 管理**：配置不当导致环境混乱。缓解：记录 Flag 状态于 `docs/reference/01-DEVELOPER-QUICK-REFERENCE.md`，并在 `logs/plan402/flag-history.log` 记录切换。
-
-402C 验收通过后，才允许进入 402D 的切换与回收；未通过前禁止关闭旧表写路径。
-
----
-
-### 子计划 402D · 切换与回收
-
-状态：待启动（依赖 402A~402C 全部验收通过）  
-依赖：402C 双写稳定、Plan 222/Plan 255 门禁、Plan 401 快照刷新、Plan 215 文档治理  
-覆盖范围：一次性数据迁移、切换流程、前端适配、测试与回滚
-
-**目标**
-1. 完成 SOM 正式切换：停止旧表写入、以视图或镜像保障只读，所有服务改为使用 SOM 数据。
-2. 更新前端 Temporal/管理界面接入 `standardObjectAdapter`，并在 Playwright/Obs 证据中证明功能完好。
-3. 跑通全套门禁与回滚演练，确保出现问题时可快速恢复旧实现。
-
-**工作项**
-- **D1 · 切换执行**：  
-  - 执行 `standardobject-migrator` 在生产级数据上完成最终导入，并运行 validator 确认无差异；日志存入 `logs/plan402/migration/*.log`、`logs/plan402/validator/*.json`。  
-  - 关闭旧仓储写路径（Feature Flag 默认 `true`，旧表改为视图只读或直接冻结），同时更新监控/告警规则。  
-  - 输出切换 Runbook（步骤、负责人、回滚条件），并签字确认。  
-- **D2 · 前端与查询适配**：  
-  - 前端（组织/职位相关页面）接入 `standardObjectAdapter`，删除组织特有的冗余字段；完成 `npm run test`、`npm run test:e2e`，Playwright 证据落入 `logs/plan402/ui/*.log`。  
-  - GraphQL/REST 查询全面指向 SOM（视图或直接查询），并更新缓存/selector/OBS 事件。  
-- **D3 · 门禁 & 回滚**：  
-  - 跑通 `make test`、`make test-db`、`scripts/quality/*`、Plan 255/Plan 252/259 守卫，并记录在 `logs/plan402/verification/*.log`。  
-  - 编写 Goose Down + 数据回滚脚本（恢复旧表写入、清理 SOM 记录），并在 staging 环境实测；在 `logs/plan402/rollback/*.log` 记录演练结果。  
-  - 交付切换报告（包含时间线、负责人、指标、风险、回滚状态），存入 `docs/development-plans/402-switch-report.md` 或归档目录。  
-
-**交付物**
-- 切换 Runbook + 执行报告、迁移/验证日志、监控指标截图。
-- 前端适配 diff（含 adapter/selector 改动）、Playwright/性能日志。
-- 回滚脚本、演练记录、门禁运行日志。
-
-**验收标准**
-- 切换完成后所有写操作仅落在 SOM，`organization_units` 表保持只读或归档，监控显示 0 双写差异。
-- 前端 UI 与 GraphQL/REST 功能在 SOM 模式下通过全量测试（含 Playwright 关键场景）。
-- 回滚演练通过：能够在 30 分钟内恢复旧表写入并保证数据一致；演练日志和脚本可复用。
-
-**风险**
-- **切换失败**：大规模数据迁移期间出现错误。缓解：严格遵循 Runbook，设置保守回滚点，提前在 staging 压测。  
-- **前端回归**：适配过程中漏改字段。缓解：严格跑 `npm run test:e2e`、`make frontend-dev` 守卫，并由 Plan 222 前端负责人复核。  
-- **监控缺失**：切换后没有及时发现异常。缓解：在 D1 前就配置 SOM 专用指标/告警（写入失败、差异、快照延迟）。
-
-402D 完成后，进入 402E 做善后治理（清理旧表/文档/OBS 等）。
-
----
-
-### 子计划 402E · 收敛与治理（可选/善后）
-
-状态：待启动（依赖 402D 完成并稳定运行至少 1 个迭代）  
-依赖：402D 切换报告、Plan 215 文档治理、Plan 400/401 更新、Plan 272 运行产物治理  
-覆盖范围：旧表/触发器清理、文档/监控同步、OBS/指标完善、未来模块接入指南
-
-**目标**
-1. 清理 `organization_units` 等旧实现遗留（表、触发器、仓储、文档引用），只保留必要视图或归档。
-2. 将 SOM 成果纳入全局文档（Plan 400/401、开发者速查、API 契约索引），确保唯一事实来源。
-3. 完善监控/OBS 体系，沉淀未来模块接入指南，使 SOM 成为默认模式。
-
-**工作项**
-- **E1 · 数据与代码清理**：  
-  - 删除/归档旧表（如 `organization_units_backup_temporal`）、触发器、迁移脚本；若需保留视图，明确只读属性。  
-  - 清理 `internal/organization` 中不再使用的仓储/DTO/触发器逻辑；更新 `standardobject` Port 作为唯一入口。  
-  - 在 `database/migrations` 中提供清理脚本（例如 `20251215090000_drop_legacy_org_tables.sql`），并记录日志。  
-- **E2 · 文档与治理**：  
-  - 更新 `docs/reference/01-DEVELOPER-QUICK-REFERENCE.md`、Plan 400/401 章节，注明 SOM 为唯一事实来源，旧表已退场。  
-  - 在 `docs/development-plans/00-README.md`、`docs/reference/temporal-entity-experience-guide.md` 登记新的参考链接。  
-  - 将 402 计划归档到 `docs/archive/development-plans/`，保留验收标准与证据索引。  
-- **E3 · 监控/OBS/未来指南**：  
-  - 为 SOM 相关操作（版本创建、链接更新）配置指标/告警、OBS 事件规范；将日志路径纳入 Plan 272 的运行产物治理。  
-  - 编写《SOM 接入指南》，指导 payroll/workforce 等未来模块如何复用 `standardobject` Port、迁移策略、测试要求。  
-  - 在 `scripts/quality/` 追加守卫（如验证旧表未再被引用、`standardobject` schema hash 检查）。  
-
-**交付物**
-- 数据/代码清理脚本及执行日志、仓储清理 MR。
-- 更新后的参考文档、归档版本（含验收标准、证据索引）。
-- 监控/OBS 配置、SOM 接入指南、质量守卫脚本。
-
-**验收标准**
-- 仓库中不再存在直接引用 `organization_units` 的生产代码（除兼容视图），`rg organization_units` 仅出现在归档或视图文件中。
-- 文档索引与开发者速查全部指向 SOM；Plan 400/401/402 归档更新完毕。
-- 监控/OBS 指标上线，Plan 272 运行产物治理脚本记录最新产物；质量守卫可以阻止回退到旧表实现。
-
-**风险**
-- **遗留引用遗漏**：某些脚本/工具仍依赖旧表。缓解：在 `scripts/quality/architecture-validator.js` 中新增检查；运行 `rg`/CI 守卫确认。  
-- **文档不同步**：多个计划/参考文件引用旧实现。缓解：在 E2 列出文档清单，使用 `scripts/document-sync` 验证。  
-- **监控空白**：若不及时建立 SOM 指标，后续问题难以排查。缓解：在 Plan 272 指标治理中新增 SOM 专项任务。  
-
-402E 完成后，Plan 402 进入归档阶段，SOM 成为组织/职位以及后续模块的唯一事实来源。
+详细执行、交付物与验收标准请参阅对应子计划文档（402A~402E）。本文件仅保留总体背景与输出清单，避免跨层信息重复。
 
 ---
 
 ## 6. 风险与缓解
+
 
 | 风险 | 影响 | 缓解 |
 |------|------|------|
@@ -391,9 +206,9 @@
 1. 《Standard Object 映射规格》 + 单表退场评估（附映射表/风险）。  
 2. `database/migrations/20251201090000_create_standard_objects.sql`（或后续补丁）与 sqlc 生成物。  
 3. `internal/standardobject/**` Port/Repository、`internal/organization/**` / `internal/position/**` 适配 diff。  
-4. `cmd/tools/standardobject-migrator`、`cmd/tools/standardobject-validator`、闭包/快照 refresh 日志。  
-5. `frontend` adapter、表单配置与 Playwright 证据。  
-6. `logs/plan402/*`：迁移/校验/测试/回滚完整链路。
+4. `cmd/tools/standardobject-migrator`、`cmd/tools/standardobject-validator`、`cmd/tools/standardobject-snapshot-refresh` 及快照/闭包 refresh 日志。  
+5. `frontend` adapter、Manifest/Slot 接入、契约生成的 forms/columns 与 Playwright/Preflight 证据。  
+6. `logs/plan402/*`：迁移/校验/快照/事件总线/测试/回滚完整链路（含 `logs/plan402/eventbus/*.log`）。  
 
 ---
 

--- a/docs/development-plans/402A-standard-object-mapping-and-contracts.md
+++ b/docs/development-plans/402A-standard-object-mapping-and-contracts.md
@@ -1,0 +1,68 @@
+# 402A · Standard Object 映射与契约准备
+
+**关联计划**：Plan 400（架构）、Plan 402（总体迁移）、Plan 403（元模型组成）  
+**状态**：拟立项  
+**依赖**：`docs/api/openapi.yaml`、`docs/api/schema.graphql`、`internal/standardobject/**` skeleton、Plan 201 sqlc 规范  
+**日志要求**：`logs/plan402/mapping/*.log`、`logs/plan402/mapping/dec-gap.log`、`logs/plan402/mapping/naming-check.log`
+
+> 目标：在实施任何数据库/服务迁移前，完成 `organization_units` → Standard Object 三表的字段映射、契约定义与兼容层设计，确保“先契约后实现”。
+
+---
+
+## 1. 目标
+
+1. 形成《Standard Object 映射规格》，将 Plan 402 §4.1/4.2 的映射表转化为可执行规范，明确字段来源、转换规则与回滚策略。
+2. 在 REST / GraphQL 契约中引入 Standard Object 实体、枚举与权限 scope，并对接 Plan 252/259 守卫。
+3. 定义临时兼容策略（视图/Port/Feature Flag 的需求与接口约束），并把具体实现交给 402B/402C；A 阶段仅需产出契约说明和迁移矩阵，确保 402B 能据此落地。
+
+---
+
+## 2. 工作项
+
+### A1 · 文档固化
+- 在现有 Plan 400/402 的基础上，补充 `docs/development-plans/402A-standard-object-mapping-spec.md`，只记录字段映射与迁移矩阵（字段→目标表/列、数据转换/验证 SQL、触发器替代、异常/回滚流程及负责人）。
+- DEC/OCL 绑定继续以 Plan 400 的 Schema Registry (`standard_object_schemas` + `schema-registry.json`) 为唯一事实来源，不再新增脚本；若发现缺口，在映射规格中登记并创建 hazard list，由 402B 的 Schema Registry 扩展解决。
+- 命名一致性依赖现有质量守卫（`scripts/quality/architecture-validator.js` 等），A 阶段仅需记录检查结果，不再自建脚本。
+
+### A2 · 契约补全
+- 更新 `docs/api/openapi.yaml`/`docs/api/schema.graphql`，新增 Standard Object 端点、类型、权限 scope，并在 `logs/plan402/mapping/api-contract.log` 记录 `node scripts/quality/contract-checker.js` 与 GraphQL codegen 的输出。
+- 通过现有命令 (`npm --prefix frontend run contract:generate`) 同步前端类型，无需新增脚本；把 PBAC 改动同步到 Plan 252/259 与参考手册。
+
+### A3 · 兼容策略说明（设计层）
+- 在映射规格中描述需要的兼容视图/Port/Feature Flag（用途、依赖、回滚原则），但将实际 SQL/代码实现放在 402B/402C 执行。
+- 记录 Feature Flag 的配置方式（环境变量名、默认值、回滚路径），由 402C 在命令/查询服务中具体落地。
+- OCL 约束在 Schema Registry 中维护；A 阶段只需列出需校验的场景，由 402B 的 Schema Registry 扩展与 402C 的校验工具执行。
+
+---
+
+## 3. 交付物
+
+- `docs/development-plans/402A-standard-object-mapping-spec.md`（含字段映射、迁移矩阵、回滚 checklist），并引用 Plan 400 Schema Registry 的 DEC/OCL 信息。
+- 兼容策略说明（视图/Port/Feature Flag 需求与回滚原则），供 402B/402C 实施；无需在 A 阶段提供 SQL/代码。
+- OpenAPI / GraphQL diff 及 Scope 更新说明，附 `scripts/quality/architecture-validator.js`、`node scripts/quality/contract-checker.js` 的输出。
+- `internal/standardobject/adapter/*.go` skeleton + Feature Flag 文档，`go test ./internal/standardobject/...` 日志。
+- `logs/plan402/mapping/*.log`（DEC gap、命名检查、视图 explain、评审会议记录）。
+
+---
+
+## 4. 验收标准
+
+1. `docs/development-plans/402A-standard-object-mapping-spec.md` 通过评审并在 `docs/development-plans/00-README.md` 登记；评审记录写入 `logs/plan402/mapping/spec-review.log`。
+2. 契约更新通过 `scripts/quality/architecture-validator.js`、`node scripts/quality/contract-checker.js`，日志落在 `logs/plan402/mapping/api-contract.log`。
+3. 兼容策略说明清楚视图/Port/Feature Flag 的需求、默认值与回滚流程，并将实现责任转交 402B/402C；无需在 A 阶段提交编译日志。
+4. Schema Registry（Plan 400）中针对组织/职位对象的 DEC/OCL 绑定被引用到映射规格中，如发现缺口则记录 hazard list 并在 402B 执行前补齐。
+
+---
+
+## 5. 风险与缓解
+
+| 风险 | 影响 | 缓解措施 |
+|------|------|----------|
+| 契约变更影响现有客户端 | 前端或集成方出现编译/运行错误 | 提前同步 Plan 222 负责人，发布 schema diff 与迁移指南 |
+| 视图性能不足 | 迁移期查询退化 | 输出 explain plan 与基准测试，必要时增加索引或物化视图 |
+| DEC/OCL 信息缺失 | Schema Registry 无法成为 SSoT | 在 hazard list 中记录缺口，限定回收期限并跟进 Plan 400/403 |
+| Feature Flag/回滚策略不明确 | 切换/回退困难 | 在 A3 文档中列出步骤、负责人、日志路径，并提前演练 |
+
+---
+
+完成 402A 后方可启动 402B。未经 402A 验收，禁止对数据库 schema 或仓储进行 Standard Object 相关改动。

--- a/docs/development-plans/402B-som-schema-and-tooling.md
+++ b/docs/development-plans/402B-som-schema-and-tooling.md
@@ -1,0 +1,82 @@
+# 402B · SOM Schema 与工具链
+
+**关联计划**：Plan 400、Plan 402、Plan 403  
+**状态**：待启动（依赖 402A 输出）  
+**范围**：数据库迁移、sqlc 生成、迁移/校验工具、快照/Schema Registry、日志规范  
+**日志要求**：`logs/plan402/migration/*.log`、`logs/plan402/validator/*.json`、`logs/plan402/snapshots/*.log`、`logs/plan402/schema/*.log`、`logs/plan402/metrics/*.log`
+
+> 目标：在数据库与工具链层面构建 Standard Object 三表、Schema Registry、迁移/校验工具与快照骨架，为服务接入与双写奠定基础。
+
+---
+
+## 1. 目标
+
+1. 使用 Atlas/Goose 创建 `standard_objects`、`standard_object_versions`、`standard_object_links` 等表，并提供 Up/Down 脚本与触发器。
+2. 更新 `sqlc.yaml` 和 `internal/standardobject/repository/sqlc`，提供标准化仓储接口。
+3. 交付 `cmd/tools/standardobject-migrator`、`cmd/tools/standardobject-validator`、`cmd/tools/standardobject-snapshot-refresh` 等工具，形成迁移与快照刷新流水线。
+4. 完成 Schema Registry、翻译、附件、元数据、指标等扩展表以及日志样例，确保 DEC/OCL 校验可执行。
+
+---
+
+## 2. 工作项
+
+### B1 · 迁移脚本
+- 创建 `20251201090000_create_standard_objects.sql`（Up/Down），包含三表、索引、约束、触发器（`is_current`、链接级联等）。
+- 在同批脚本中加入 `standard_object_hierarchy_snapshots` 等 Plan 401 依赖的骨架，并在注释中标明用途。
+- 更新 `database/migrations/README.md`，记录执行顺序与回滚说明；`logs/plan402/migration/*.log` 保存 `atlas diff` / `goose up`。
+
+### B2 · sqlc & 包结构
+- 调整 `sqlc.yaml`，生成 `internal/standardobject/repository/sqlc` 所需的 CRUD、列表、链接维护查询。
+- 在 `internal/standardobject/domain` 创建实体、DTO 与接口，提供 `ObjectRepository`、`LinkRepository` 等 Port。
+- 更新 `make sqlc-generate` pipeline 并记录日志，确保 CI/本地生成一致。
+
+### B3 · 迁移/校验工具
+- `cmd/tools/standardobject-migrator`：读取旧表写入 SOM，支持 dry-run、批次、失败回滚；输出 `logs/plan402/migration/migrator-*.log`。
+- `cmd/tools/standardobject-validator`：对比计数、哈希、层级一致性，并执行 Schema Registry/DEC/OCL 校验；输出 `logs/plan402/validator/*.json`。
+- 提供工具使用手册及异常回滚指引。
+
+### B4 · 快照刷新骨架
+- 交付 `cmd/tools/standardobject-snapshot-refresh`（或同等 Job），实现快照/物化视图刷新、dry-run、限速、指标输出。
+- 在 `logs/plan402/snapshots/*.log` 保存运行记录（含快照版本、耗时）；失败场景需附回滚/重试说明。
+- 在《Standard Object 映射规格》中补充快照/闭包校验项，并更新开发者速查命令。
+
+### B5 · 通用维度扩展
+- 建立 `standard_object_schemas` 表，包含 `dec_bindings`、`ocl_guards`、`glossary_url` 等字段，生成 `schema-registry.json`。
+- 创建 `standard_object_translations`、`standard_object_attachments`、`standard_object_metadata`、`standard_object_metrics` 等扩展表与 sqlc 代码。
+- 在 `logs/plan402/schema/*.log`、`logs/plan402/metrics/*.log` 输出首批样例。
+
+---
+
+## 3. 交付物
+
+- `database/migrations/20251201090000_create_standard_objects.sql`（Up/Down）与 `atlas diff` 日志。
+- 更新后的 `sqlc.yaml`、`internal/standardobject/repository/sqlc` 代码与 `make sqlc-generate` 日志。
+- `cmd/tools/standardobject-migrator`、`standardobject-validator`、`standardobject-snapshot-refresh` 源码/说明及运行日志。
+- `logs/plan402/migration/*.log`、`logs/plan402/validator/*.json`、`logs/plan402/snapshots/*.log`、`logs/plan402/schema/*.log`、`logs/plan402/metrics/*.log` 样例。
+- Schema Registry（含 DEC/OCL）、翻译、附件、元数据、指标表结构与 `schema-registry.json`。
+
+---
+
+## 4. 验收标准
+
+1. `make db-migrate-all` / `make db-rollback-last` 在 Docker Compose 环境中通过，并将输出写入 `logs/plan402/migration/*.log`.
+2. `make sqlc-generate` 在本地与 CI 均成功，`git status` 清洁；Plan 201 差异项脚本通过。
+3. migrator/validator 在沙盒数据集上跑通，产出差异报告；出现差异时提供可执行对账结论。
+4. Schema Registry 生成物通过 DEC/OCL 缺失检查，`logs/plan402/schema/*.log` 无告警。
+5. 快照刷新工具完整运行一次，`logs/plan402/snapshots/*.log` 记录耗时/数据量；失败案例具备回滚记录。
+6. `scripts/quality/architecture-validator.js` 或辅助脚本验证仓库内不存在 `effective_from/effective_to` 字段引用，结果写入 `logs/plan402/mapping/naming-check.log`。
+
+---
+
+## 5. 风险与缓解
+
+| 风险 | 影响 | 缓解措施 |
+|------|------|----------|
+| Schema 约束与旧数据冲突 | 迁移失败或数据不一致 | migrator 中提供修复策略、hazard list，必要时阻断上线 |
+| sqlc 生成不一致 | CI/本地差异导致编译失败 | 锁定 sqlc 版本/配置，纳入 `make sqlc-generate` 守卫 |
+| 工具运行性能不足 | 迁移/校验耗时过长或锁表 | 支持批次、限速、dry-run；记录性能指标 |
+| DEC/OCL 数据缺失 | Schema Registry 不可用 | 在 Schema 生成脚本中强制校验，缺失即失败 |
+
+---
+
+402B 验收通过后，方可启动 402C；在此之前禁止服务层引用 SOM 仓储，避免双事实来源。

--- a/docs/development-plans/402C-service-integration-and-double-write.md
+++ b/docs/development-plans/402C-service-integration-and-double-write.md
@@ -1,0 +1,91 @@
+# 402C · 服务接入与双写
+
+**关联计划**：Plan 400、Plan 401、Plan 402、Plan 403、Plan 252/259、Plan 300  
+**状态**：待启动（依赖 402A/402B 通过）  
+**范围**：命令/查询服务接入 SOM、Feature Flag、双写/校验、outbox 与快照刷新、前端 Manifest、能力契约日志  
+**日志要求**：`logs/plan402/doublewrite/*.log`、`logs/plan402/validator/*.json`、`logs/plan402/eventbus/*.log`、`logs/plan402/ui/*.log`、`logs/plan402/schema/*.log`、`logs/plan402/metrics/*.log`、`logs/plan402/capability/*.log`
+
+> 目标：在不破坏现有服务的前提下，让组织/职位模块通过 Standard Object 端口运行，建立双写与自动校验机制，并完善前端/权限/事件链路。
+
+---
+
+## 1. 目标
+
+1. 命令/查询服务通过 `internal/standardobject/api.go` 的 Port 操作 SOM，并保持 `STANDARD_OBJECTS_ENABLED` Feature Flag 可控。
+2. 构建双写与自动校验（含 DEC/OCL 巡检），确保旧表与 SOM 数据一致且可快速回滚。
+3. 接入 outbox 事件、快照刷新、GraphQL 缓存与前端 Manifest/Slot，确保读取路径以 SOM 为主。
+4. 将能力契约与视点矩阵证据纳入 `logs/plan402/capability/*.log`，保证与 Plan 400/403 一致。
+
+---
+
+## 2. 工作项
+
+### C1 · Port 接入
+- 在 `cmd/hrms-server/command/internal/organization|position` 注入 `ObjectCommandService`，并保留旧仓储用于回滚。
+- 查询服务（GraphQL）通过 `internal/standardobject/query` 读取 SOM 或视图，完善 DTO/Resolver。
+- `STANDARD_OBJECTS_ENABLED` Feature Flag 记录默认值与回滚步骤；每次切换在 `logs/plan402/flag-history.log` 留痕。
+- 每次接入需在 `logs/plan402/capability/*.log` 记录 Federate、版本与视点覆盖。
+
+### C2 · 双写与校验
+- 写路径：Flag 开启时同时写 SOM 与旧表，并输出 `logs/plan402/doublewrite/*.log`。
+- 读路径：Flag 开启→读 SOM；关闭→读旧表，保证回滚安全。
+- 校验任务：使用 `standardobject-validator` 或自定义任务比对数据，并执行 DEC/OCL 巡检；异常时自动切回旧表并输出 `logs/plan402/validator/*.json`。
+
+### C3 · Outbox / 快照
+- Outbox dispatcher 写入 `standard_object.*` 事件，刷新快照与下游模块；`logs/plan402/eventbus/*.log` 记录配置与指标。
+- 快照/闭包在写操作后触发刷新，复用 402B 的 refresh job，并在 `logs/plan402/snapshots/*.log` 留痕。
+- 更新缓存/GraphQL 数据加载器，确保 `standard_object_links` 驱动层级查询。
+
+### C4 · 前端 / Manifest
+- 组织/职位页面通过 Manifest/Slot (`temporal:organization:*`, `temporal:position:*`) 调用 `standardObjectAdapter`，禁止散落 GraphQL/REST 客户端。
+- 运行 `scripts/generate-forms-from-openapi.ts`、`scripts/generate-columns-from-graphql.ts`（或等效脚本），保证 UI 字段与契约同步；输出 `logs/plan400/manifest/*.log` & `logs/plan402/ui/*.log`。
+- PBAC scope 取自 OpenAPI（Plan 252/259），通过 Manifest `requiredScopes` 控制显隐。
+
+### C5 · 权限/事件治理
+- 在 Plan 252/259 数据源中新增 `standardObject.*` scope，更新 `scripts/quality/auth-permission-contract-validator.js`。
+- EventBus Adapter 使用持久化传输（Redis/Asynq 等），记录部署/监控配置。
+
+### C6 · 通用维度消费
+- 写路径校验 Schema Registry（哈希 + JSON Schema + DEC/OCL），违规返回契约错误；记录 `logs/plan402/schema/*.log`。
+- 前端读取 `standard_object_translations`、附件、metadata；指标写入 `logs/plan402/metrics/*.log`，供监控面板使用。
+
+### C7 · 视点与能力验收
+- 按 Plan 400 视点矩阵输出结构/运行/观察/协作证据，双写巡检必须包含视点名称与能力契约 ID。
+- `scripts/quality/architecture-validator.js` 在 capabilityContracts 规则中检查新增对象类型/Tab 是否已登记。
+
+---
+
+## 3. 交付物
+
+- 命令/查询服务改造 diff、Port/Adapter 注入代码、Feature Flag 配置与回滚脚本。
+- 双写运行日志 `logs/plan402/doublewrite/*.log`、自动校验报告 `logs/plan402/validator/*.json`。
+- Outbox / 快照 / EventBus 配置与 `logs/plan402/eventbus/*.log`、`logs/plan402/snapshots/*.log`。
+- Manifest/Slot diff、`standardObjectAdapter` 更新、`logs/plan402/ui/*.log`、`logs/plan400/manifest/*.log`。
+- Schema Registry / 翻译 / 附件 / 指标消费代码与 `logs/plan402/schema/*.log`、`logs/plan402/metrics/*.log`。
+- 能力契约日志 `logs/plan402/capability/*.log`（含视点矩阵校验）。
+
+---
+
+## 4. 验收标准
+
+1. `STANDARD_OBJECTS_ENABLED=true/false` 两种模式下，`make test`、`make test-db`、`npm run test` 全量通过。
+2. 双写期间 `standardobject-validator` 无差异（或差异在允许范围且具备回滚策略），异常可在 5 分钟内切回旧表。
+3. Outbox/快照链路跑通，Plan 401/Plan 250 检查通过，`logs/plan402/eventbus/*.log` 无告警。
+4. `npm run quality:preflight`、`npm run test:e2e` 通过，生成物与 `docs/api/*` 契约一致。
+5. Plan 252/259 守卫与 capability 合规检查通过；`logs/plan402/capability/*.log`、`logs/plan400/ui/*.log` 证据齐全。
+6. Schema Registry 校验、翻译/附件渲染、`data_classification`/指标透传在测试/CI 中有证据，并确认 0 漂移/0 丢失。
+
+---
+
+## 5. 风险与缓解
+
+| 风险 | 影响 | 缓解措施 |
+|------|------|----------|
+| 双写不一致 | 生产数据异常 | 事务内双写 + 自动校验，异常即切回旧表并告警 |
+| 性能退化 | 写入/校验延迟 | 批量写、异步校验、监控 TPS / 延迟，必要时降级只读模式 |
+| Feature Flag 管理混乱 | 不同环境行为不一致 | 记录 Flag 变更，集中在 `logs/plan402/flag-history.log` 并由负责人审批 |
+| Manifest/前端更新滞后 | UI 不一致或测试失败 | 强制通过生成器更新 forms/columns，并将 Playwright/OBS 作为验收前置 |
+
+---
+
+402C 通过后方可启动 402D；在此之前不得关闭旧表写路径。

--- a/docs/development-plans/402D-cutover-and-recovery.md
+++ b/docs/development-plans/402D-cutover-and-recovery.md
@@ -1,0 +1,69 @@
+# 402D · 切换与回收
+
+**关联计划**：Plan 400、Plan 401、Plan 402、Plan 222/255、Plan 300  
+**状态**：待启动（依赖 402A~402C 完成）  
+**范围**：一次性迁移、Feature Flag 切换、前端/查询适配、门禁与回滚演练  
+**日志要求**：`logs/plan402/migration/*.log`、`logs/plan402/validator/*.json`、`logs/plan402/ui/*.log`、`logs/plan402/verification/*.log`、`logs/plan402/rollback/*.log`、`logs/plan402/capability/*.log`
+
+> 目标：将所有读写切换至 Standard Object 三表，停用旧 `organization_units` 写入，完成前端/查询适配与门禁验收，并验证回滚路径。
+
+---
+
+## 1. 目标
+
+1. 执行最终迁移与校验，关闭旧仓储写路径，确保只读或归档。
+2. 更新前端与查询层，使其完全依赖 SOM，并完成 Playwright/OBS 证据。
+3. 跑通所有门禁（Go/前端/质量脚本），并完成 Goose Down + 数据回滚演练。
+4. 输出切换 Runbook、执行报告与能力契约核对结果。
+
+---
+
+## 2. 工作项
+
+### D1 · 切换执行
+- 运行 `cmd/tools/standardobject-migrator` 对生产级数据进行最终导入，日志写入 `logs/plan402/migration/*.log`。
+- 执行 `standardobject-validator` 确认 0 差异，附 `logs/plan402/validator/*.json`。
+- 关闭旧仓储写路径（Feature Flag 默认开启 SOM），旧表仅保留只读视图或直接冻结。
+- 输出切换 Runbook（步骤、负责人、回滚条件）与 DEC/OCL 体检报告，确保 `schema-registry.json` 与能力契约无缺口。
+
+### D2 · 前端与查询适配
+- 前端（组织/职位页面）完全接入 `standardObjectAdapter`；清理组织特有冗余字段。
+- 重新运行 `npm run quality:preflight`、`npm run test`、`npm run test:e2e`，并把日志写入 `logs/plan402/ui/*.log`。
+- GraphQL/REST 查询切换至 SOM 数据源，更新缓存/selector/OBS 事件；Manifest/Slot 记录 DEC 列表与视点。
+
+### D3 · 门禁与回滚
+- 跑通 `make test`、`make test-db`、`scripts/quality/*`（含 capabilityContracts 规则），输出 `logs/plan402/verification/*.log`。
+- 编写 Goose Down + 数据回滚脚本，并在 staging 演练；日志存入 `logs/plan402/rollback/*.log`。
+- 在 `scripts/quality/architecture-validator.js` 中运行 capability contract 完整性检查，确认 4.3 表格条目覆盖全部 Federate。
+
+---
+
+## 3. 交付物
+
+- 切换 Runbook 与执行报告、迁移/校验日志、DEC/OCL 体检报告。
+- 前端/查询适配 diff、Manifest/Slot 更新、Playwright/OBS 证据 (`logs/plan402/ui/*.log`)。
+- 门禁运行日志 (`logs/plan402/verification/*.log`)、回滚脚本与演练记录 (`logs/plan402/rollback/*.log`)。
+- 能力契约核对结果 (`logs/plan402/capability/*.log`)。
+
+---
+
+## 4. 验收标准
+
+1. 切换后所有写操作仅落在 `standard_objects*`，旧表只读或归档，监控显示 0 双写差异。
+2. 前端 UI 与 GraphQL/REST 功能在 SOM 模式下通过全量测试（含 Playwright 核心场景），日志齐全。
+3. DEC/OCL 体检报告 0 漏项、0 违规，能力契约矩阵覆盖所有视点；相关证据已存档。
+4. 回滚演练可在 30 分钟内恢复旧实现并保证数据一致。
+
+---
+
+## 5. 风险与缓解
+
+| 风险 | 影响 | 缓解措施 |
+|------|------|----------|
+| 切换期间出现异常 | 数据不一致或服务中断 | 严格按 Runbook 执行，设置回滚点并实时监控 |
+| 前端回归遗漏 | UI/交互异常 | 强制执行 Playwright/OBS 证据，Plan 222 负责人复核 |
+| 监控缺失 | 无法及时发现问题 | 切换前配置 SOM 专用指标与告警，纳入 Plan 272 |
+
+---
+
+402D 完成后方可启动 402E；若出现重大问题，必须通过回滚脚本恢复旧数据路径并记录 `logs/plan402/rollback/*.log`。

--- a/docs/development-plans/402E-convergence-and-governance.md
+++ b/docs/development-plans/402E-convergence-and-governance.md
@@ -1,0 +1,69 @@
+# 402E · 收敛与治理（可选）
+
+**关联计划**：Plan 400、Plan 401、Plan 215、Plan 272、Plan 403  
+**状态**：待启动（依赖 402D 完成并稳定运行至少一个迭代）  
+**范围**：旧表/代码清理、文档与索引更新、监控/OBS 完善、未来模块接入指南  
+**日志要求**：`logs/plan402/cleanup/*.log`、`logs/plan402/capability/*.log`（更新记录）、`logs/plan402/metrics/*.log`
+
+> 目标：在 SOM 切换稳定后，清理历史实现、完善文档/监控/质量守卫，并沉淀未来模块接入指南。
+
+---
+
+## 1. 目标
+
+1. 清除 `organization_units` 等旧表、触发器与遗留仓储，只保留受控视图或归档。
+2. 更新参考文档（Plan 400/401、开发者速查、Plan 00-README 等），确保 SOM 成为唯一事实来源。
+3. 完善监控/OBS/质量守卫，例如 capability-contract-check、schema hash 校验等。
+4. 产出《SOM 接入指南》，指导 payroll/workforce 等未来模块复用 Standard Object。
+
+---
+
+## 2. 工作项
+
+### E1 · 数据与代码清理
+- 删除/归档旧表及触发器（必要时提供 Goose Down 脚本），保留只读视图以兼容历史查询。
+- 清理 `internal/organization` 等目录下不再使用的仓储/DTO，并确保所有生产代码仅调用 `internal/standardobject` Port。
+- 更新 `database/migrations`，附执行日志 `logs/plan402/cleanup/*.log`。
+
+### E2 · 文档与索引
+- 更新 `docs/reference/01-DEVELOPER-QUICK-REFERENCE.md`、Plan 400/401、Plan 403 等文档，声明 SOM 为唯一事实来源。
+- 在 `docs/development-plans/00-README.md`、`docs/reference/standard-object-evidence-guide.md` 等索引中添加最新链接。
+- 将 Plan 402 主文档与子计划按规范归档到 `docs/archive/development-plans/`，保留验收标准与证据索引。
+- 发布《能力契约与视点维护指南》，并在 `scripts/quality/capability-contract-check.js` 或架构验证器中纳入检查。
+
+### E3 · 监控 / OBS / 接入指南
+- 为 SOM 相关操作配置指标与告警，将日志采集纳入 Plan 272 的运行产物治理脚本。
+- 编写《SOM 接入指南》，说明如何使用 Schema Registry、Port、Manifest/Slot、能力契约，并给出回滚/日志要求。
+- 在 `scripts/quality/` 中新增守卫（如验证仓库不再引用旧表、Schema hash 校验、capability contract 检查）。
+
+---
+
+## 3. 交付物
+
+- 数据/代码清理脚本、执行日志 (`logs/plan402/cleanup/*.log`)。
+- 更新后的 Plan 400/401/403、开发者速查、参考指南，以及归档版本。
+- 监控/OBS 配置、SOM 接入指南、质量守卫脚本。
+- `logs/plan402/capability/*.log` 中的维护记录。
+
+---
+
+## 4. 验收标准
+
+1. 生产代码中不再存在对 `organization_units` 的直接引用（除只读视图或归档），CI 守卫能够检测该情况。
+2. 文档索引与开发者速查全部指向 SOM，并在 `docs/development-plans/00-README.md` 登记。
+3. 监控/OBS 指标上线，Plan 272 的运行产物治理脚本记录最新产物。
+4. 质量守卫（capability contract、schema hash、旧表引用检测等）可阻止回退到旧实现。
+
+---
+
+## 5. 风险与缓解
+
+| 风险 | 影响 | 缓解措施 |
+|------|------|----------|
+| 遗留引用遗漏 | 旧逻辑悄然复活 | 在 `scripts/quality/architecture-validator.js` 增加检查；运行 `rg organization_units` 并制定白名单 |
+| 文档不同步 | 团队引用旧资料 | 建立文档清单与审核流程，更新 `docs/reference/standard-object-evidence-guide.md` |
+| 监控/守卫缺失 | 回归无法及时发现 | 在 Plan 272/255 守卫中加入 SOM 专项脚本，强制在 PR/CI 运行 |
+
+---
+
+402E 完成后，Plan 402 可归档；后续模块接入需直接引用 Plan 400/401/403、能力契约与证据指南。

--- a/docs/development-plans/403-SOM元模型组成优化建议.md
+++ b/docs/development-plans/403-SOM元模型组成优化建议.md
@@ -1,0 +1,421 @@
+
+# **标准对象模型（SOM）设计与元模型组成架构深度研究报告**
+
+## 0\. 事实来源与适用范围
+
+- **唯一事实来源**：本计划只接受本仓库既有契约与计划作为实现依据，包括 `docs/development-plans/400-standard-object-model-plan.md`、`docs/development-plans/402-standard-object-single-source-plan.md`、`docs/api/openapi.yaml`、`docs/api/schema.graphql`、`database/migrations/` 与 `internal/standardobject/**`。外部规范仅作参考背景，不能替代上述契约。
+- **适用范围**：所有建议最终需落地到 `standard_objects*` 迁移、`internal/standardobject` Go 端口、前端 `frontend/src/features/temporal/**`、以及 `logs/plan40x/*` 证据。若某项分析无法映射到这些产物，须在本文件中标明“不采纳”并转入 `docs/archive/`。
+- **引用策略**：文末列出的 ISO/MOF/HLA 等资料仅用于阐释概念；真正的执行步骤、字段清单、脚本命令都必须引用仓库内文档与目录，确保“资源唯一性与跨层一致性”。
+## **1\. 执行摘要与战略背景**
+
+随着大规模分布式仿真、企业级系统集成以及模型驱动工程（Model-Driven Engineering, MDE）的飞速发展，建立一套具备高度互操作性、可扩展性且语义严谨的“标准对象模型”（Standard Object Model, SOM）已成为系统工程领域的关键挑战。SOM不仅定义了系统间信息交换的静态结构，更承载了动态行为契约与领域语义规则。然而，传统单体式（Monolithic）的SOM设计在面对日益复杂的业务需求时，逐渐暴露出维护困难、复用性低以及语义歧义等深层次问题。本报告针对SOM设计的核心——“元模型组成”（Meta-model Composition）展开详尽研究，旨在为下一代SOM架构提供理论支撑与实施路径。
+
+本研究深入剖析了对象管理组织（OMG）的元对象设施（MOF）、高层体系结构（HLA）的对象模型模板（OMT）、ISO 19109地理信息通用特征模型（GFM）以及ISO 42010架构描述标准等多维度的技术规范。分析表明，元模型组成并非简单的文件拼接，而是一个涉及命名空间管理、语义融合、约束传播及版本演进的复杂系统工程。
+
+报告首先确立了基于四层元建模架构（Four-layered Metamodel Architecture）的理论基础，指出SOM设计的重心应从模型层（M1）上移至元模型层（M2），通过定义领域特定的元类型系统来实现能力的灵活配置。随后，报告批判性地评估了现有的组合技术，包括MOF的包合并（Package Merge）机制、HLA的模块化FOM技术以及基于Mixin的特征混入模式。研究发现，虽然MOF的包合并机制提供了强大的增量定义能力，但其复杂的语义和实现难度往往导致“大元模型”陷阱；相比之下，基于核心-扩展（Core-Extension）的轻量级组合模式配合严格的语义锚点（Semantic Anchoring）更适应现代敏捷开发的需求。
+
+此外，本报告还重点探讨了语义互操作性的深层挑战，建议引入ISO 11179元数据注册标准来解决跨域元模型组合时的语义歧义问题，并利用对象约束语言（OCL）实施跨模块的组合验证。最后，针对SOM的长期演进，报告提出了基于变更记录（Change-based）的模型迁移策略，以确保标准升级过程中的资产保值。
+
+---
+
+## **2\. 标准对象模型（SOM）的多维定义与架构基础**
+
+### **2.1 概念溯源：从软件组件到领域建模**
+
+“标准对象模型”这一术语在计算机科学的不同分支中承载着不同的历史使命。理解这些差异对于确立本方案的设计目标至关重要。
+
+在软件工程的早期阶段，SOM主要解决的是跨语言、跨进程的二进制互操作性问题。例如，微软的组件对象模型（COM）和分布式COM（DCOM）定义了一套二进制接口标准，使得C++编写的组件可以被Visual Basic脚本调用 1。与此同时，对象管理组织（OMG）推出的公共对象请求代理体系结构（CORBA）则定义了一套基于IDL（接口定义语言）的标准对象模型，旨在实现异构网络环境下的分布式对象通信 3。这些早期的SOM关注点在于“接口”与“传输”，而非“语义”与“结构”的灵活性。
+
+随着Web技术的发展，文档对象模型（DOM）成为了另一种形态的SOM，它为HTML和XML文档定义了标准的编程接口，使得脚本语言可以动态访问和更新文档的内容、结构及样式 1。这里的SOM不仅是接口，更是一种树状的数据结构规范。
+
+而在仿真领域，特别是美国国防部主导的高层体系结构（HLA）中，SOM（Simulation Object Model）的含义发生了质的飞跃。它不再仅仅是编程接口，而是仿真成员（Federate）向外部世界公开其能力的一种声明式契约。HLA OMT（Object Model Template）详细规定了SOM必须包含的对象类、交互类、属性、参数及其更新策略 6。这种SOM是“自我描述”的，它允许联邦在运行时动态发现成员的能力，从而支持即插即用的互操作性。
+
+**综合洞察**：本方案所指的SOM设计，应当超越底层的二进制互操作（如COM）和单纯的文档结构（如DOM），向HLA SOM及领域建模的高级语义靠拢。它应该是一套**元模型系统**，用于定义特定领域内实体的**类型系统**、**属性结构**及**交互规则**。
+
+### **2.2 四层元建模架构（The Four-Layered Architecture）**
+
+要解决“元模型组成”的问题，必须首先明确SOM在元建模架构中的定位。OMG定义的四层架构是分析此类问题的标准坐标系 8。
+
+| 层级 | 名称 | 定义描述 | 在SOM设计中的具体映射 | 关键特征 |
+| :---- | :---- | :---- | :---- | :---- |
+| **M3** | **元-元模型** (Meta-Meta-Model) | 定义构建元模型的语言。它是自描述的，通常不可变。 | **基础设施层**。例如：OMG MOF, Eclipse Ecore, Kermeta。SOM的设计工具基于此层构建。 | 极度抽象，提供Class, Attribute, Reference等基础构件。 |
+| **M2** | **元模型** (Meta-Model) | 定义模型的语言。它是M3的实例。 | **SOM标准层**。这是本方案的设计核心。SOM的结构（如Vehicle, Sensor, Event）在此层定义。 | 领域相关，定义了业务规则和类型系统。 |
+| **M1** | **模型** (Model) | 现实世界的抽象表示。它是M2的实例。 | **用户应用层**。用户基于SOM标准创建的具体场景（如“红蓝对抗场景”）。 | 具体化，描述特定的业务配置。 |
+| **M0** | **实例** (Instance/Data) | 运行时的具体数据。它是M1的实例。 | **运行时层**。仿真运行时的对象状态（如“坦克\#001的位置(x,y)”）。 | 动态变化，存在于内存或数据库中。 |
+
+在SOM设计中，一个常见的误区是将本应属于M1层的内容硬编码到M2层。例如，将“T-72坦克”直接定义为SOM的一个元类（Meta-class）。这会导致元模型过于庞大且频繁变动。正确的做法是在M2层定义“地面平台（GroundPlatform）”元类，而在M1层通过实例化描述“T-72坦克”。**元模型组成**的核心任务，就是讨论如何将M2层的不同模块（如“物理模型包”、“通信模型包”）组合起来，以支持M1层构建出具备完整能力的模型。
+
+### **2.3 领域特定视角的SOM差异**
+
+不同领域的SOM设计对“组成”有着不同的诉求：
+
+* **地理信息系统（GIS）**：ISO 19109定义的通用特征模型（GFM）是GIS领域的元模型。它强调特征（Feature）的分类和属性的定义。在GIS中，元模型组成往往表现为将多个应用模式（Application Schema）集成到一个全局视图中，解决的是空间数据的语义对齐问题 12。  
+* **企业业务建模**：在语义对象模型（Semantic Object Model, SOM）方法论中，企业系统被视为交互的业务对象网络。这里的SOM设计强调多视点（Multi-view）的协调，如企业计划视图、业务过程视图和资源视图的统一 15。  
+* **分布式仿真（HLA）**：HLA的SOM强调模块化FOM（Modular FOM），关注的是不同仿真联邦成员之间的数据交换协议的拼接。其核心挑战在于如何处理不同模块对同一对象类的扩展和重定义 17。
+
+---
+
+## **3\. 元模型组成（Meta-model Composition）的理论机制**
+
+“元模型组成”是解决复杂系统建模问题的关键技术。它允许设计者将一个庞大的元模型拆解为若干个关注点分离的单元，再通过特定机制进行重组。本章将深入剖析当前主流的几种组合机制及其优劣。
+
+### **3.1 OMG MOF 包合并（Package Merge）机制深度剖析**
+
+OMG在UML 2.0规范中引入了包合并（Package Merge）机制，作为模块化构建UML元模型的核心手段 19。
+
+#### **3.1.1 机制原理**
+
+包合并是一种定义在两个包之间的有向二元关系：ReceivingPackage（接收包）合并 MergedPackage（被合并包）。这不仅仅是简单的引用（Import），而是一种**定义性增强**。
+
+* **匹配规则（Match Rule）**：合并机制首先根据名称（Name）和元类型（Meta-type）来识别两个包中的对应元素。例如，如果两个包中都有名为Element的类，它们就被视为匹配。  
+* **合并规则（Merge Rule）**：匹配的元素会被融合。被合并包中的属性、操作和约束会被添加到接收包的对应元素中。如果接收包中不存在对应元素，则直接深拷贝（Deep Copy）19。  
+* **递归性**：包合并是递归执行的。如果包中包含子包，子包也会按照相同的规则进行合并。
+
+#### **3.1.2 语义与用途**
+
+包合并的主要用途是增量式定义（Incremental Definition）。例如，MOF Core首先定义最基本的Element。然后，Constructs包通过合并Core，向Element注入“注释（Comment）”能力。Kernel包再通过合并Constructs，注入“所有权（Ownership）”能力。最终的UML元模型是这一系列合并操作的结果 20。  
+这种机制允许设计者将横切关注点（如“标识符”、“版本控制”）封装在独立的包中，然后通过合并将其“织入”到主元模型中，类似于面向切面编程（AOP）。
+
+#### **3.1.3 批判与局限**
+
+尽管MOF包合并在理论上非常优雅，但在工程实践中却遭受了广泛的批评，甚至被戏称为“大元模型是邪恶的”（Big Metamodels Are Evil）23。
+
+* **语义晦涩与实现困难**：MOF规范中关于合并冲突的解决规则极其复杂。例如，当两个包对同一个类的同一个属性定义了不同的约束（如重数不同）时，如何合并？规范往往留有解释空间，导致不同工具（如IBM RSA, NoMagic, Eclipse UML2）的实现行为不一致 24。  
+* **溯源性丧失**：在合并后的结果模型中，很难分辨某个特性究竟来自哪个源包。这使得调试和验证变得异常困难。设计者面对一个合并后的庞大类，往往无法理清其继承脉络。  
+* **版本管理噩梦**：当底层被合并包发生微小变更时，由于深拷贝机制，所有上层包都需要重新计算和验证，这在大型分布式开发中是不可接受的。
+
+### **3.2 导入（Import）与继承（Inheritance）的传统路径**
+
+除了激进的包合并，传统的元建模工具（如Eclipse Ecore）更倾向于使用\*\*包导入（Package Import）**配合**类继承（Class Inheritance）\*\*来实现组合 25。
+
+* **机制**：包A导入包B，使得包A可见包B中的元素。然后包A中的类ClassA显式继承包B中的ClassB。  
+* **对比合并**：  
+  * **继承**创建了新的子类，原有的基类保持不变。这符合面向对象设计的基本原则（Liskov替换原则）。  
+  * **合并**修改了定义的含义，产生了一个融合后的新定义。  
+* **优劣**：继承机制简单清晰，工具支持好，无歧义。但它难以处理“横切关注点”。例如，若想给系统中所有的类都增加一个UUID字段，使用继承需要让所有类都继承自一个新的基类，这可能破坏原有的继承树（单继承限制）；而包合并则可以直接将UUID注入到根类中。
+
+### **3.3 方面导向建模（Aspect-Oriented Modeling, AOM）与Mixin模式**
+
+为了克服继承的僵化和合并的复杂，学术界和工业界探索了基于\*\*方面（Aspects）**和**特征（Traits/Mixins）\*\*的组合技术 27。
+
+* **MATA与AspectualACME**：这些研究项目提出了在元模型层面应用AOP的方法。通过定义“切点（Pointcut）”和“通知（Advice）”，可以将特定的元模型片段（如安全策略、日志记录）自动编织到基础元模型中。这种方法比MOF包合并更灵活，因为它基于模式匹配而非仅仅是名称匹配 27。  
+* **Mixin模式**：Scala等语言中的Trait机制被引入元建模。一个元类可以由一个主类和多个Trait组合而成。Trait不持有状态（或持有抽象状态），主要提供行为契约。在SOM设计中，这意味着可以将“可序列化”、“可持久化”等能力定义为Mixin，并在构建具体SOM时按需混入 28。
+
+### **3.4 比较分析总结**
+
+下表总结了三种主要组合机制在SOM设计中的适用性：
+
+| 特性指标 | MOF 包合并 (Package Merge) | 继承与引用 (Inheritance & Import) | 方面与混入 (AOM & Mixins) |
+| :---- | :---- | :---- | :---- |
+| **语义机制** | 结构融合，定义重写 | 子类型化，接口扩展 | 行为注入，横切关注点分离 |
+| **可溯源性** | 低 (Deep Copy掩盖来源) | 高 (显式继承链) | 中 (需工具支持切面可视化) |
+| **实现难度** | 极高 (工具支持不一) | 低 (所有OOP/MDE工具支持) | 中高 (需专用编织器) |
+| **灵活性** | 高 (支持侵入式修改) | 低 (受限于单继承) | 极高 (支持动态组合) |
+| **SOM推荐度** | **慎用** (仅限核心标准定义) | **基础使用** (构建类型层级) | **推荐** (实现模块化特征扩展) |
+
+---
+
+## **4\. SOM元模型组成的架构模式设计**
+
+基于上述理论分析，针对用户构建“标准对象模型”的目标，本报告提出三种核心架构模式。这些模式并非互斥，而是可以在不同层级上组合使用。
+
+### **4.1 核心-扩展模式（Core-Extension Pattern）**
+
+这是最稳健且被广泛采用的SOM架构模式，广泛应用于ISO标准和工业级框架中 30。
+
+> **与仓库实施的关联**：Plan 400 已将 `standard_objects` 视为 Core (`ObjectKernel`)，`standard_object_versions`/`standard_object_links` 作为 Extension（TemporalVersion/Link）。因此 403 方案在讨论核心-扩展时，默认聚焦于这些目录：  
+> - `database/migrations/20251201090000_create_standard_objects.sql`：负责 Core/Extension 表结构。  
+> - `internal/standardobject/domain` 与 `internal/standardobject/repository/sqlc`：承载核心接口、扩展策略实现。  
+> - `docs/api/openapi.yaml` / `schema.graphql`：提供 Core/Extension 的唯一契约出口。  
+> 后续所有模式分析均需要回到这些产物，严禁提出无法映射到上述目录的抽象要求。
+
+#### **4.1.1 架构定义**
+
+* **核心层（The Core）**：定义SOM最基础的元概念。它必须保持极简、紧凑且高度稳定。通常包括：  
+  * Object (对象基类)  
+  * Property (属性定义)  
+  * Relationship (关系定义)  
+  * DataType (基础数据类型)  
+  * Identity (标识机制)  
+* **扩展层（The Extensions）**：所有特定领域的知识都封装在扩展包中。扩展包通过依赖核心层来定义新的元类或对核心元类进行特化。
+
+#### **4.1.2 扩展点的设计**
+
+为了使核心层具备强大的扩展能力，必须预留明确的**扩展点（Extension Points）**：
+
+* **构造型（Stereotypes）**：借鉴UML Profile机制，允许扩展包定义Stereotype来修饰核心元素。例如，仿真扩展包定义\<\<Simulated\>\>构造型，应用到Core的Object上，使其获得updateRate属性 31。  
+* **抽象钩子（Abstract Hooks）**：在核心层定义抽象类或接口（如AbstractBehavior），扩展包通过实现这些接口来注入具体逻辑。  
+* **元数据注解（Annotations）**：允许在核心元素上挂载键值对形式的元数据，这是实现轻量级扩展的最低成本方式 34。
+
+#### **4.1.3 案例：ISO 21000-5 REL**
+
+ISO 21000-5（权利表达语言）采用了典型的Core-Extension结构。其Base profile是预先分解的核心，提供了基础语法；而各种多媒体扩展则建立在此基础之上。这种设计平衡了标准化的刚性与业务需求的柔性 33。
+
+### **4.2 模块化联邦模式（The Modular Federation Pattern）**
+
+借鉴HLA Evolved (IEEE 1516-2010) 的模块化FOM设计，这种模式特别适用于多方协作、分布式开发的SOM环境 7。
+
+> **仓库映射**：模块化联邦在本项目中对应“组织/职位/未来模块通过 `internal/standardobject/api.go` 端口接入同一 SOM”。Plan 402 拆分的 402A~402E 即是 Federation 阶段：  
+> - `organization` 模块充当 Federate，提供 `ORG_HIERARCHY` 能力（写入/读取 `standard_object_links`）。  
+> - `position` 模块是第二个 Federate，依赖组织的事件与 Link。  
+> - 任何新增模块必须在 `docs/development-plans/402-capability-contracts.md` 登记能力矩阵，并附 `logs/plan402/capability/*.log` 证据。  
+> 403 文档中对“模块化联邦”的要求应直接转化为上述文档/日志的更新，而不是笼统描述。
+
+#### **4.2.1 模块化原理**
+
+在这种模式下，SOM不再是一个单一的文件，而是一个**模块库（Module Repository）**。
+
+* **SOM模块**：每个模块描述了一组相关的对象类和交互类。例如，“通信模块”定义了无线电、报文等对象；“后勤模块”定义了补给站、物资等对象。  
+* **组合配置（Composition Configuration）**：用户通过一个配置文件（如FOM Module Description file）声明所需的模块列表。  
+* **运行时拼接**：系统加载器在初始化阶段读取配置，加载所有模块，并解析它们之间的依赖关系。如果模块A和模块B都扩展了同一个基类Vehicle，加载器需要负责合并这些扩展。
+
+#### **4.2.2 解决“钻石依赖”与冲突**
+
+模块化模式面临的最大挑战是依赖冲突。例如，模块B和C都扩展了模块A，而模块D同时依赖B和C。
+
+* **HLA的解决方案**：HLA OMT通过表格合并算法来处理。对于对象类，取并集；对于属性，检查数据类型一致性。HLA Evolved引入了更严格的命名空间和模块标识符来辅助这一过程 18。  
+* **改进建议**：本报告建议在SOM设计中引入更严格的**语义版本控制（Semantic Versioning）和能力契约（Capability Contracts）**。模块不应仅仅声明依赖，还应声明其提供的“能力集”。
+
+### **4.3 多视点投影模式（Multi-View Projection Pattern）**
+
+基于ISO 42010架构描述标准，这种模式强调从不同的涉干者（Stakeholder）视角来组织SOM 15。
+
+> **执行要求**：Plan 400 §4.8 已定义“结构/运行/观察/协作”四个视点，并通过 `logs/plan400/schema/*.log`, `logs/plan400/snapshots/*.log`, `logs/plan400/ui/*.log` 等路径留痕。本计划需确保任何新模式/模块在提交时同步更新该视点矩阵，并把证据落在相同日志目录。若 403 中提出新的视点或指标，必须说明插入到哪条日志路径、哪个守卫脚本，避免出现第二事实来源。
+
+#### **4.3.1 视点（Viewpoint）与视图（View）**
+
+* **视点**：定义了构建和使用视图的约定（Conventions）。在SOM设计中，可以定义“结构视点”、“行为视点”、“安全视点”等。  
+* **视图**：是符合特定视点的模型集合。  
+* **对应关系（Correspondence）**：不同视图之间的元素必须建立链接。例如，结构视图中的“服务器”对象，必须与安全视图中的“受保护资产”对象相对应。
+
+#### **4.3.2 组合的含义**
+
+在这种模式下，元模型组成不仅仅是数据的合并，而是**视点的叠加**。SOM的设计应当支持将多个视图模型（View Models）综合成一个系统级的整体模型。这要求元模型具备描述“对应规则（Correspondence Rules）”的能力。例如，规则可以定义：“凡是在功能视图中被标记为‘关键’的组件，在部署视图中必须有冗余备份” 36。
+
+---
+
+## **5\. 语义互操作性与歧义消除策略**
+
+在组合来自不同来源的SOM模块时，\*\*语义异构性（Semantic Heterogeneity）\*\*是导致系统失效的主要原因。同名异义（Homonymy）和异名同义（Synonymy）是两大顽疾。本章提出基于语义锚点的解决方案。
+
+### **5.1 语义标注与ISO 11179集成**
+
+ISO 11179（元数据注册标准）提供了一套标准化的框架来描述数据的含义 37。
+
+#### **5.1.1 引入数据元素概念（DEC）**
+
+建议SOM元模型中不仅包含“名称（Name）”和“类型（Type）”，还必须包含指向外部语义库的引用。
+
+* **架构设计**：在M2层的Element元类中增加semanticReference属性。  
+* **语义库**：建立一个基于ISO 11179的元数据注册库（MDR）。库中存储**数据元素概念（Data Element Concept, DEC）**。例如，DEC ID 123-456 代表“飞行器的当前海拔高度”。  
+* **绑定机制**：  
+  * SOM模块A定义属性 Alt，绑定语义ID 123-456。  
+  * SOM模块B定义属性 Height，绑定语义ID 123-456。  
+  * **组合逻辑**：当组合引擎处理模块A和B时，检测到两个属性指向同一DEC，系统可以自动识别它们为同义词，并根据预设规则（如优先使用主模块命名）进行合并或建立映射 40。
+
+### **5.2 消除语义歧义的高级技术**
+
+除了静态的语义ID绑定，还可以引入更动态的消歧技术 42。
+
+* **上下文感知消歧**：利用上下文信息（如模块所属的领域标签）来区分多义词。例如，在“金融”上下文中，Bond指债券；在“化学”上下文中，Bond指化学键。SOM元模型应支持定义\*\*领域上下文（Domain Context）\*\*属性，辅助自动匹配工具进行判断 44。  
+* **本体对齐（Ontology Alignment）**：在高级应用中，可以将SOM模块导出为OWL本体。利用现有的本体匹配算法（如基于图结构相似度、WordNet词汇相似度）来发现潜在的语义冲突。例如，如果两个类具有完全相同的属性集和相似的交互关系，即使名称不同，算法也会提示它们可能是同一概念 37。
+
+---
+
+## **6\. 验证、一致性与循环依赖管理**
+
+元模型的组合过程极易引入逻辑矛盾和结构错误。必须建立严格的验证体系。
+
+### **6.1 集成对象约束语言（OCL）**
+
+UML和MOF标准都依赖OCL来表达无法用图形符号描述的精确规则。SOM设计必须原生支持OCL 45。
+
+#### **6.1.1 多级约束验证**
+
+* **元模型层约束**：验证SOM本身的设计是否合法。例如，“继承深度不能超过10层”，“属性名不能为空”。这些约束应当固化在M3层的元-元模型中。  
+* **组合层约束**：这是关键。当模块A和模块B组合时，需要验证跨模块的业务规则。例如，模块A规定“所有车辆最大速度 \< 100”，模块B扩展出的“赛车”定义最大速度为200。OCL引擎必须能捕捉到这种**不变量冲突（Invariant Conflict）** 48。
+
+#### **6.1.2 组合验证工作流**
+
+1. **加载**：加载所有参与组合的SOM模块。  
+2. **解析**：解析所有嵌入的OCL约束表达式。  
+3. **标准化**：将约束转换为标准逻辑公式（如SMT-LIB格式）。  
+4. **求解**：调用SMT求解器（如Z3）检查约束集的可满足性（Satisfiability）。如果不可满足，报告冲突的具体约束条目 49。
+
+### **6.2 循环依赖的处理算法**
+
+在模块化设计中，循环依赖（Circular Dependency）是系统稳定性的天敌。例如，模块A依赖B，B依赖C，C又依赖A 50。
+
+#### **6.2.1 危害**
+
+* **初始化死锁**：在系统启动时，无法确定模块加载顺序。  
+* **版本锁定**：升级任何一个模块都需要同步升级环中的所有模块，导致“依赖地狱”。
+
+#### **6.2.2 检测与解耦策略**
+
+* **Tarjan强连通分量算法**：在SOM构建工具中实现Tarjan算法。将模块视为图的节点，依赖视为有向边。算法可以线性时间复杂度地检测出图中的所有强连通分量（即循环依赖环）51。  
+* **架构解耦模式**：  
+  * **提取接口层（Interface Extraction）**：如果A和B循环依赖，通常是因为它们互相使用了对方的具体实现。解决方案是创建一个基础模块Base，定义接口IA和IB。A和B都改为依赖Base，从而打断环。  
+  * **依赖倒置（DIP）**：确保高层模块不依赖低层模块的细节，二者都依赖抽象。  
+  * **回调机制**：在SOM交互定义中，使用事件/回调模式代替直接的对象引用 51。
+
+---
+
+## **7\. SOM的演进与生命周期管理**
+
+标准对象模型不是静态的，它必须随着业务需求的变化而演进。如何处理元模型变更导致的旧数据失效问题，是SOM设计必须考虑的生命周期管理问题。
+
+### **7.1 元模型漂移与模型迁移（Model Migration）**
+
+当SOM元模型从v1.0升级到v2.0（例如，将User.name拆分为firstName和lastName），基于v1.0创建的数据文件将无法被v2.0的解析器读取。这称为“元模型漂移” 53。
+
+#### **7.1.1 Edapt模式：基于操作记录的迁移**
+
+Eclipse Edapt项目提供了一种经过验证的最佳实践 55。
+
+* **原理**：不应仅仅记录元模型的“状态快照”，而应记录导致状态变化的“操作历史（Operation History）”。  
+* **实现**：SOM设计工具应能够捕获设计者的重构操作（如RenameAttribute, MoveClass, SplitAttribute）。  
+* **迁移器生成**：基于操作历史，工具自动生成迁移脚本（Migrator）。当加载旧版数据时，迁移脚本按顺序重放这些操作的逻辑，将数据自动转换为新版结构。  
+* **价值**：这种机制使得SOM的演进不再是破坏性的，极大降低了标准升级的阻力。
+
+### **7.2 语义版本控制策略**
+
+对SOM模块实施严格的语义版本控制（Semantic Versioning, SemVer）58。
+
+* **MAJOR（主版本）**：当做了不兼容的API修改（如删除类、修改约束使其更严格）。  
+* **MINOR（次版本）**：当做了向下兼容的功能性新增（如增加可选属性、放宽约束）。  
+* **PATCH（修订号）**：当做了向下兼容的问题修正（如修正描述文案）。
+
+**最佳实践**：SOM加载器应支持“版本范围”依赖（如 requires: "VehicleModule \>= 1.2.0 \< 2.0.0"）。这允许系统在保证兼容性的前提下自动使用最新的补丁版本，同时避免加载不兼容的主版本更新。
+
+---
+
+## **8\. 高级范式：超越传统元建模**
+
+为了应对极端复杂的建模需求，SOM设计可以探索超越传统四层架构的前沿范式。
+
+### **8.1 多级建模与深层实例化（Deep Instantiation）**
+
+在某些领域，四层架构（M0-M3）显得过于僵化。例如，在定义“波音747”时，它既是一个类（相对于具体的B747-400飞机），又是“飞机模型”这个类的一个实例。传统的元建模强制要求将其硬塞入某一层，导致概念扭曲 60。
+
+* **深层实例化原理**：允许定义跨越多个层级的属性。在SOM中，可以定义一个属性具有potency（效力）。  
+  * potency=1：常规属性，在下一层实例化时必须赋值。  
+  * potency=2：属性在下一层保持为“类型属性”，在下下层才被赋值。  
+* **SOM应用**：通过支持深层实例化，SOM可以极大地压缩元模型的层级，减少不必要的元类定义，使模型更加扁平化和易于理解。
+
+### **8.2 角色-对象模式（Role-Object Pattern）**
+
+在仿真和动态系统中，实体的身份往往是流动的。一个实体可能在不同时间扮演不同角色。传统的继承机制（class Soldier extends Human）在处理这种动态性时非常笨拙（如果士兵退役变成了平民怎么办？）。
+
+* **模式设计**：建议SOM采用**角色-对象模式** 62。  
+  * **Core层**：定义Subject（主体）和Role（角色）两个基类。  
+  * **关系**：Subject 可以拥有多个 Role。  
+  * **动态绑定**：允许在运行时动态地向Subject添加或移除Role。  
+* **优势**：这种模式将“类型组合”推迟到了运行时（M0层），提供了极致的灵活性，特别适合那些需求频繁变更的复杂系统仿真。
+
+---
+
+## **9\. 结论与实施路线图**
+
+综上所述，构建一个完善的标准对象模型（SOM）及其元模型组成机制，需要综合考虑架构模式、语义标准、验证技术及演进策略。本报告建议采取以下分阶段实施路线：
+
+1. **第一阶段：核心稳固（Kernel Stabilization）**  
+   * 基于EMOF/Ecore确立SOM的M3语言基础。  
+   * 设计精简的Core元模型，仅包含对象、属性、关系等原子概念。  
+   * 引入OCL验证引擎，确立基础约束能力。  
+2. **第二阶段：模块化与语义增强（Modularization & Semantics）**  
+   * 实现基于Core-Extension的扩展机制，支持Mixin模式。  
+   * 建立符合ISO 11179的语义注册库，实施强制性的语义ID绑定。  
+   * 开发依赖管理工具，支持Tarjan算法检测循环依赖。  
+3. **第三阶段：生态构建与演进（Ecosystem & Evolution）**  
+   * 实现基于Edapt的自动模型迁移工具链。  
+   * 支持多视点（Multi-view）投影，对接ISO 42010架构标准。  
+   * 探索多级建模和角色对象模式，以适应未来超复杂系统的需求。
+
+通过这一系统性的设计路径，SOM将从一个静态的数据交换格式，进化为一个具备自我描述、自我验证及平滑演进能力的智能建模生态系统，从而真正实现“标准对象模型”的设计初衷——在混乱的数字世界中建立秩序与连接。
+
+---
+
+## **10\. 与现有计划和产物的映射**
+
+| 403 要素 | 对应事实来源/产物 | 执行要求 |
+|---------|--------------------|----------|
+| 核心-扩展/对象内核 | `docs/development-plans/400-standard-object-model-plan.md §4.1`、`database/migrations/20251201090000_create_standard_objects.sql`、`internal/standardobject/domain` | 任意新增字段/接口必须同步更新上述计划与迁移脚本，并附 `logs/plan400/sqlc-generate.log`、`logs/plan400/atlas-diff.log` 证明生成物最新。 |
+| 模块化联邦/能力契约 | `docs/development-plans/402-standard-object-single-source-plan.md §4.3、§402A-402E`、`docs/development-plans/402-capability-contracts.md`（需补充）、`logs/plan402/capability/*.log` | 每个 Federate（organization/position/未来模块）都要登记提供/依赖的能力，CI 通过 `scripts/quality/architecture-validator.js` 校验；403 的联邦建议默认以该表为 SSoT。 |
+| 多视点矩阵 | `docs/development-plans/400-standard-object-model-plan.md §4.8`、`logs/plan400/schema|snapshots|ui/*.log`、`frontend/tests/e2e` | 403 中对视点/OBS 的拓展须列出对应日志路径和测试脚本，禁止新建未受控的证据目录。 |
+| ISO 11179 / OCL | `standard_object_schemas` 表、`schema-registry.json`、`internal/standardobject/policy`、`pkg/ocl`（计划内目录） | 语义锚点与 OCL 建议必须转化为 `dec_bindings`、`ocl_guards`、`logs/plan400/schema/*.log` 等实体，且引用的 DEC 需在 Schema Registry 注册。 |
+| 多级建模（potency） | `standard_objects.object_type_potency`、`object_type_inheritance`、`docs/development-plans/400-standard-object-model-plan.md §4.9` | 深层实例化示例要说明如何在这些字段中配置，并提供 migrator/validator 任务输出 `logs/plan400/migration/*.log`。 |
+| 读模型/快照/OBS | `cmd/tools/standardobject-snapshot-refresh`、`standard_object_hierarchy_snapshots`、`logs/plan400/snapshots/*.log`、`logs/plan400/ui/*.log` | “运行/观察”建议默认映射到这些工具与日志，新增指标需更新脚本与守卫。 |
+| 前端适配/Manifest | `frontend/src/features/temporal/**`、`scripts/generate-forms-from-openapi.ts`、`scripts/generate-columns-from-graphql.ts`、`logs/plan400/manifest/*.log` | 多视点与模块化建议若涉及前端，需指明使用现有 adapter/生成脚本，并更新 Manifest/Slot 与 obs 证据。 |
+
+> **核对流程**：当 403 方案新增条款时，作者必须在 PR 描述中引用上表中至少一项产物，review 以此为 checklist 逐项核对，确保本文件永远与 Plan 400/402 的事实来源保持一致。
+
+---
+
+**(报告结束)**
+
+#### **引用的著作**
+
+1. What is an object model? \- Quora, 访问时间为 十一月 23, 2025， [https://www.quora.com/What-is-an-object-model](https://www.quora.com/What-is-an-object-model)  
+2. XML \- Managing Data Exchange/Glossary \- Wikibooks, open books for an open world, 访问时间为 十一月 23, 2025， [https://en.wikibooks.org/wiki/XML\_-\_Managing\_Data\_Exchange/Glossary](https://en.wikibooks.org/wiki/XML_-_Managing_Data_Exchange/Glossary)  
+3. THE DoD HIGH LEVEL ARCHITECTURE: AN UPDATE1 \- Georgia Institute of Technology, 访问时间为 十一月 23, 2025， [https://sites.cc.gatech.edu/computing/pads/PAPERS/High\_Level\_Architecture\_For\_Simulation.pdf](https://sites.cc.gatech.edu/computing/pads/PAPERS/High_Level_Architecture_For_Simulation.pdf)  
+4. Meta-Object Facility \- Wikipedia, 访问时间为 十一月 23, 2025， [https://en.wikipedia.org/wiki/Meta-Object\_Facility](https://en.wikipedia.org/wiki/Meta-Object_Facility)  
+5. Chapter no.7:-  
+6. 2003: DISTRIBUTED SIMULATION SYSTEMS, 访问时间为 十一月 23, 2025， [https://www.informs-sim.org/wsc03papers/015.pdf](https://www.informs-sim.org/wsc03papers/015.pdf)  
+7. (PDF) An overview of the HLA evolved modular FOMs \- ResearchGate, 访问时间为 十一月 23, 2025， [https://www.researchgate.net/publication/266262757\_An\_overview\_of\_the\_HLA\_evolved\_modular\_FOMs](https://www.researchgate.net/publication/266262757_An_overview_of_the_HLA_evolved_modular_FOMs)  
+8. The Meta-Object Facility (MOF), 访问时间为 十一月 23, 2025， [https://wiki.eclipse.org/images/0/06/OMCW\_chapter04\_MOFLecture.York.pdf](https://wiki.eclipse.org/images/0/06/OMCW_chapter04_MOFLecture.York.pdf)  
+9. Serialisation of EMF models \- eclipse \- Stack Overflow, 访问时间为 十一月 23, 2025， [https://stackoverflow.com/questions/15532960/serialisation-of-emf-models](https://stackoverflow.com/questions/15532960/serialisation-of-emf-models)  
+10. Ecore vs MOF \- EMF \- Eclipse Foundation, 访问时间为 十一月 23, 2025， [https://www.eclipse.org/forums/index.php/t/127040/](https://www.eclipse.org/forums/index.php/t/127040/)  
+11. A Metamodel Family for Role-Based Modeling and Programming Languages \- Qucosa \- TU Dresden, 访问时间为 十一月 23, 2025， [https://tud.qucosa.de/api/qucosa%3A75371/attachment/ATT-0/](https://tud.qucosa.de/api/qucosa%3A75371/attachment/ATT-0/)  
+12. ISO 19109:2025 \- Standard Norge | standard.no, 访问时间为 十一月 23, 2025， [https://online.standard.no/iso-19109-2025-3](https://online.standard.no/iso-19109-2025-3)  
+13. ISO 19109:2015 Geographic information \- Rules for application schema \- ICA Wiki, 访问时间为 十一月 23, 2025， [https://wiki.icaci.org/index.php?title=ISO\_19109:2015\_Geographic\_information\_-\_Rules\_for\_application\_schema](https://wiki.icaci.org/index.php?title=ISO_19109:2015_Geographic_information_-_Rules_for_application_schema)  
+14. Attributes of feature types (adapted from ISO 19109\) \- ResearchGate, 访问时间为 十一月 23, 2025， [https://www.researchgate.net/figure/Attributes-of-feature-types-adapted-from-ISO-19109\_fig2\_240927894](https://www.researchgate.net/figure/Attributes-of-feature-types-adapted-from-ISO-19109_fig2_240927894)  
+15. Using Conceptual Modeling for Designing Multi-View Modeling Tools \- CORE, 访问时间为 十一月 23, 2025， [https://core.ac.uk/download/pdf/301366037.pdf](https://core.ac.uk/download/pdf/301366037.pdf)  
+16. Bridging the Gap from a Multi-View Modelling Method, 访问时间为 十一月 23, 2025， [https://emisa-journal.org/emisa/article/download/106/81](https://emisa-journal.org/emisa/article/download/106/81)  
+17. Enabling Simulation Interoperability between International Standards in the Space Domain \- NASA Technical Reports Server, 访问时间为 十一月 23, 2025， [https://ntrs.nasa.gov/api/citations/20220009047/downloads/DS\_RT\_2022.pdf](https://ntrs.nasa.gov/api/citations/20220009047/downloads/DS_RT_2022.pdf)  
+18. (PDF) New Object Modeling Opportunities in HLA 4 \- ResearchGate, 访问时间为 十一月 23, 2025， [https://www.researchgate.net/publication/331320274\_New\_Object\_Modeling\_Opportunities\_in\_HLA\_4](https://www.researchgate.net/publication/331320274_New_Object_Modeling_Opportunities_in_HLA_4)  
+19. (PDF) Techniques for Metamodel Composition \- ResearchGate, 访问时间为 十一月 23, 2025， [https://www.researchgate.net/publication/248617517\_Techniques\_for\_Metamodel\_Composition](https://www.researchgate.net/publication/248617517_Techniques_for_Metamodel_Composition)  
+20. OMG Meta Object Facility (MOF) Core Specification, 访问时间为 十一月 23, 2025， [https://www.omg.org/spec/MOF/2.4.1/PDF](https://www.omg.org/spec/MOF/2.4.1/PDF)  
+21. 7.3.40 PackageMerge, 访问时间为 十一月 23, 2025， [https://www.site.uottawa.ca/\~tcl/gradtheses/mnojoumian/ThesisFiles/FinalSpec/UML/7.3.40.html](https://www.site.uottawa.ca/~tcl/gradtheses/mnojoumian/ThesisFiles/FinalSpec/UML/7.3.40.html)  
+22. OMG Meta Object Facility (MOF) Core Specification, 访问时间为 十一月 23, 2025， [https://www.omg.org/spec/MOF/2.5.1/PDF](https://www.omg.org/spec/MOF/2.5.1/PDF)  
+23. (PDF) Big Metamodels Are Evil \- ResearchGate, 访问时间为 十一月 23, 2025， [https://www.researchgate.net/publication/278716778\_Big\_Metamodels\_Are\_Evil](https://www.researchgate.net/publication/278716778_Big_Metamodels_Are_Evil)  
+24. MOF — Open Issues \- OMG Issue Tracker, 访问时间为 十一月 23, 2025， [https://issues.omg.org/issues/spec/MOF](https://issues.omg.org/issues/spec/MOF)  
+25. EMF Core \- Eclipse Modeling Framework, 访问时间为 十一月 23, 2025， [https://eclipse.dev/modeling/emf/](https://eclipse.dev/modeling/emf/)  
+26. Package Merge semantics with nested packages and package imports \- Stack Overflow, 访问时间为 十一月 23, 2025， [https://stackoverflow.com/questions/73926920/package-merge-semantics-with-nested-packages-and-package-imports](https://stackoverflow.com/questions/73926920/package-merge-semantics-with-nested-packages-and-package-imports)  
+27. Semantics Preservation in Model-based Composition \- SciSpace, 访问时间为 十一月 23, 2025， [https://scispace.com/pdf/semantics-preservation-in-model-based-composition-27d1i5a0h9.pdf](https://scispace.com/pdf/semantics-preservation-in-model-based-composition-27d1i5a0h9.pdf)  
+28. An object-oriented approach to language compositions for software language engineering, 访问时间为 十一月 23, 2025， [https://doi.org/10.1016/j.jss.2013.04.087](https://doi.org/10.1016/j.jss.2013.04.087)  
+29. (PDF) Composition operators for modeling languages: A literature review \- ResearchGate, 访问时间为 十一月 23, 2025， [https://www.researchgate.net/publication/372733084\_Composition\_operators\_for\_modeling\_languages\_A\_literature\_review](https://www.researchgate.net/publication/372733084_Composition_operators_for_modeling_languages_A_literature_review)  
+30. Towards a Metamodel to Support the Joint Optimization of Socio Technical Systems \- MDPI, 访问时间为 十一月 23, 2025， [https://www.mdpi.com/2079-8954/2/3/273](https://www.mdpi.com/2079-8954/2/3/273)  
+31. EXTENDING THE UML FOR MODELLING VARIABILITY FOR SYSTEM FAMILIES 1\. Introduction \- Biblioteka Nauki, 访问时间为 十一月 23, 2025， [https://bibliotekanauki.pl/articles/907979.pdf](https://bibliotekanauki.pl/articles/907979.pdf)  
+32. Towards a Model-based Service Integration Framework for Extensible Enterprise Systems, 访问时间为 十一月 23, 2025， [https://webdoc.sub.gwdg.de/univerlag/2010/mkwi/03\_anwendungen/enterprise\_resource\_planning\_transformation/02\_towards\_a-model-based\_service\_integration\_framework.pdf](https://webdoc.sub.gwdg.de/univerlag/2010/mkwi/03_anwendungen/enterprise_resource_planning_transformation/02_towards_a-model-based_service_integration_framework.pdf)  
+33. Annex to OGC Policy and Procedures — The Specification Model — Structuring an OGC specification to encourage implementation \- OGC Portal \- Open Geospatial Consortium, 访问时间为 十一月 23, 2025， [https://portal.ogc.org/files/?artifact\_id=21976](https://portal.ogc.org/files/?artifact_id=21976)  
+34. The Eclipse Modeling Framework (EMF) Overview \- IBM, 访问时间为 十一月 23, 2025， [https://www.ibm.com/docs/en/wdfrhcw/1.4.0?topic=guides-emf-framework-programmers-guide](https://www.ibm.com/docs/en/wdfrhcw/1.4.0?topic=guides-emf-framework-programmers-guide)  
+35. ISO/IEC/IEEE 42010: Conceptual Model \- iso-architecture.org, 访问时间为 十一月 23, 2025， [http://www.iso-architecture.org/ieee-1471/cm/](http://www.iso-architecture.org/ieee-1471/cm/)  
+36. ﻿ISO/IEC/IEEE 42010-2022﻿, 访问时间为 十一月 23, 2025， [https://ieeexplore.ieee.org/iel7/9938424/9938445/09938446.pdf](https://ieeexplore.ieee.org/iel7/9938424/9938445/09938446.pdf)  
+37. An Ontology-based Method for Heterogeneous Data Governance with MFI and MDR, 访问时间为 十一月 23, 2025， [https://ieeexplore.ieee.org/document/10466986/](https://ieeexplore.ieee.org/document/10466986/)  
+38. Semantic Models for XML Schema with UML Tooling \- KIT \- Web Science, 访问时间为 十一月 23, 2025， [https://km.aifb.kit.edu/ws/swese2006/final/carlson\_full.pdf](https://km.aifb.kit.edu/ws/swese2006/final/carlson_full.pdf)  
+39. Model Driven Data Management in Healthcare \- Semantic Scholar, 访问时间为 十一月 23, 2025， [https://pdfs.semanticscholar.org/2982/df178363a2cbe1bbc9243e27028b2eefe63c.pdf](https://pdfs.semanticscholar.org/2982/df178363a2cbe1bbc9243e27028b2eefe63c.pdf)  
+40. Defining health data elements under the HL7 development framework for metadata management \- ResearchGate, 访问时间为 十一月 23, 2025， [https://www.researchgate.net/publication/359336058\_Defining\_health\_data\_elements\_under\_the\_HL7\_development\_framework\_for\_metadata\_management](https://www.researchgate.net/publication/359336058_Defining_health_data_elements_under_the_HL7_development_framework_for_metadata_management)  
+41. Data category overview | Download Scientific Diagram \- ResearchGate, 访问时间为 十一月 23, 2025， [https://www.researchgate.net/figure/Data-category-overview\_fig2\_29613980](https://www.researchgate.net/figure/Data-category-overview_fig2_29613980)  
+42. Identifying & Interactively Refining Ambiguous User Goals for Data Visualization Code Generation \- arXiv, 访问时间为 十一月 23, 2025， [https://arxiv.org/html/2510.09390](https://arxiv.org/html/2510.09390)  
+43. Semantic Ambiguity in Image Annotation — Why Clarity Matters \- Statswork, 访问时间为 十一月 23, 2025， [https://www.statswork.com/semantic-ambiguity-image-annotation/](https://www.statswork.com/semantic-ambiguity-image-annotation/)  
+44. Resolving Tag Ambiguity \- CS@Cornell, 访问时间为 十一月 23, 2025， [https://www.cs.cornell.edu/\~kilian/papers/ctfp6043-weinberger.pdf](https://www.cs.cornell.edu/~kilian/papers/ctfp6043-weinberger.pdf)  
+45. Validating OCL constraints in UML models \- IBM, 访问时间为 十一月 23, 2025， [https://www.ibm.com/docs/en/dma?topic=models-validating-ocl-constraints-in-uml](https://www.ibm.com/docs/en/dma?topic=models-validating-ocl-constraints-in-uml)  
+46. Validating UML models and OCL constraints \- ResearchGate, 访问时间为 十一月 23, 2025， [https://www.researchgate.net/publication/2637671\_Validating\_UML\_models\_and\_OCL\_constraints](https://www.researchgate.net/publication/2637671_Validating_UML_models_and_OCL_constraints)  
+47. Validating UML Models and OCL Constraints \- University of Iowa, 访问时间为 十一月 23, 2025， [https://homepage.cs.uiowa.edu/\~tinelli/classes/181/Spring03/Readings/Ric00.pdf](https://homepage.cs.uiowa.edu/~tinelli/classes/181/Spring03/Readings/Ric00.pdf)  
+48. Instantiation of Meta-models Constrained with OCL \- SciTePress, 访问时间为 十一月 23, 2025， [https://www.scitepress.org/Papers/2015/52314/52314.pdf](https://www.scitepress.org/Papers/2015/52314/52314.pdf)  
+49. A formal approach to finding inconsistencies in a metamodel \- Hao Wu, 访问时间为 十一月 23, 2025， [https://classicwuhao.github.io/pdf/sosym.pdf](https://classicwuhao.github.io/pdf/sosym.pdf)  
+50. Untangling Dependencies @ Scale, 访问时间为 十一月 23, 2025， [https://atscaleconference.com/untangling-dependencies-scale/](https://atscaleconference.com/untangling-dependencies-scale/)  
+51. Circular dependencies between classes: why they are bad and how to get rid of them?, 访问时间为 十一月 23, 2025， [https://stackoverflow.com/questions/43023400/circular-dependencies-between-classes-why-they-are-bad-and-how-to-get-rid-of-th](https://stackoverflow.com/questions/43023400/circular-dependencies-between-classes-why-they-are-bad-and-how-to-get-rid-of-th)  
+52. Circular dependency \- is there a good design to eliminate, 访问时间为 十一月 23, 2025， [https://softwareengineering.stackexchange.com/questions/393829/circular-dependency-is-there-a-good-design-to-eliminate](https://softwareengineering.stackexchange.com/questions/393829/circular-dependency-is-there-a-good-design-to-eliminate)  
+53. Reconstructing Complex Metamodel Evolution \- Eelco Visser, 访问时间为 十一月 23, 2025， [https://eelcovisser.org/publications/2011/VermolenWV11sle.pdf](https://eelcovisser.org/publications/2011/VermolenWV11sle.pdf)  
+54. (PDF) An analysis of approaches to model migration \- ResearchGate, 访问时间为 十一月 23, 2025， [https://www.researchgate.net/publication/228618538\_An\_analysis\_of\_approaches\_to\_model\_migration](https://www.researchgate.net/publication/228618538_An_analysis_of_approaches_to_model_migration)  
+55. EMF Forms Developer Tooling: View Model Migration \- EclipseSource, 访问时间为 十一月 23, 2025， [https://eclipsesource.com/blogs/2015/03/05/emf-forms-developer-tooling-view-model-migration/](https://eclipsesource.com/blogs/2015/03/05/emf-forms-developer-tooling-view-model-migration/)  
+56. EMF Forms Migration Guide \- EclipseSource, 访问时间为 十一月 23, 2025， [https://eclipsesource.com/blogs/tutorials/emf-forms-migration-guide/](https://eclipsesource.com/blogs/tutorials/emf-forms-migration-guide/)  
+57. Model Migration with Edapt \- YouTube, 访问时间为 十一月 23, 2025， [https://www.youtube.com/watch?v=Zn9CVM4iOUc](https://www.youtube.com/watch?v=Zn9CVM4iOUc)  
+58. Semantic Versioning 2.0.0 | Semantic Versioning, 访问时间为 十一月 23, 2025， [https://semver.org/](https://semver.org/)  
+59. \[Meta\] Backwards compatibility and deprecation warnings · Issue \#1732 · tmux/tmux \- GitHub, 访问时间为 十一月 23, 2025， [https://github.com/tmux/tmux/issues/1732](https://github.com/tmux/tmux/issues/1732)  
+60. Considering a Multi-Level Model as a Society of Interacting Models \- JASSS, 访问时间为 十一月 23, 2025， [https://www.jasss.org/18/3/7.html](https://www.jasss.org/18/3/7.html)  
+61. Multilevel Modeling. Toward a New Paradigm of Conceptual Modeling and Information Systems Design \- ResearchGate, 访问时间为 十一月 23, 2025， [https://www.researchgate.net/publication/275152525\_Multilevel\_Modeling\_Toward\_a\_New\_Paradigm\_of\_Conceptual\_Modeling\_and\_Information\_Systems\_Design](https://www.researchgate.net/publication/275152525_Multilevel_Modeling_Toward_a_New_Paradigm_of_Conceptual_Modeling_and_Information_Systems_Design)  
+62. A Role-Based Metamodeling Approach to Specifying Design Patterns \- ResearchGate, 访问时间为 十一月 23, 2025， [https://www.researchgate.net/publication/4043739\_A\_Role-Based\_Metamodeling\_Approach\_to\_Specifying\_Design\_Patterns](https://www.researchgate.net/publication/4043739_A_Role-Based_Metamodeling_Approach_to_Specifying_Design_Patterns)  
+63. A role-based metamodeling approach to specifying design patterns \- IEEE Xplore, 访问时间为 十一月 23, 2025， [https://ieeexplore.ieee.org/iel5/8813/27898/01245379.pdf](https://ieeexplore.ieee.org/iel5/8813/27898/01245379.pdf)

--- a/docs/reference/00-README.md
+++ b/docs/reference/00-README.md
@@ -93,6 +93,17 @@
 - CI 门禁与 E2E 工作流（plan-255-gates、frontend-e2e-devserver）与 VS Code 任务建议
 - SUMMARY 打印与远程抓取脚本：print-e2e-summary.js、fetch-gh-summary.sh
 
+### 🧾 [Standard Object 证据与 Schema Registry 指南](./standard-object-evidence-guide.md)
+**用途**: 统一 SOM 的 Schema Registry 字段要求、能力能力巡检与日志模板  
+**包含内容**:
+- `standard_object_schemas` 必备列（DEC/OCL/Glossary）与生成流程  
+- `logs/plan400/schema|snapshots|ui|manifest`、`logs/plan402/capability` 等证据目录说明  
+- 视点矩阵与 `architecture-validator --rule capabilityContracts` 巡检命令  
+**使用场景**:
+- ✅ Schema/能力变更前确认日志模板  
+- ✅ PR/验收时附加 DEC/OCL/能力巡检证据  
+- ✅ 规划新 Federate 或视点指标
+
 ---
 
 ## 🚀 快速开始

--- a/docs/reference/standard-object-evidence-guide.md
+++ b/docs/reference/standard-object-evidence-guide.md
@@ -1,0 +1,103 @@
+# Standard Object 证据与 Schema Registry 指南
+
+**状态**：长期有效参考  
+**唯一事实来源**：`docs/development-plans/400-standard-object-model-plan.md`、`docs/development-plans/402-standard-object-single-source-plan.md`、`docs/development-plans/403-SOM元模型组成优化建议.md`、`docs/api/openapi.yaml`、`docs/api/schema.graphql`、`database/migrations/20251201090000_create_standard_objects.sql`  
+**相关日志**：`logs/plan400/schema/*`、`logs/plan400/snapshots/*`、`logs/plan400/ui/*`、`logs/plan400/manifest/*`、`logs/plan402/capability/*`
+
+> 本指南用于说明 Standard Object（SOM）在 Schema Registry、能力巡检与证据留存方面的约束与模板。所有条目均需引用上述计划/契约，不得引入第二事实来源。
+
+---
+
+## 1. Schema Registry 要求
+
+| 字段 | 说明 | 事实来源 |
+|------|------|----------|
+| `object_type` | 对应 `standard_objects.object_type`，以 `ORGANIZATION_UNIT`/`POSITION_ROLE` 等常量表示 | Plan 400 §4.1 |
+| `schema_version` / `schema_hash` | JSON Schema 版本与 SHA256 哈希，生成时写入 `schema-registry.json` | Plan 400 §4.1 / 4.3 |
+| `definition` | JSON Schema 正文（仅使用 camelCase 字段） | OpenAPI / GraphQL 契约 |
+| `dec_bindings` | 字段路径 → ISO 11179 DEC ID / 语义说明，缺失会触发 `logs/plan400/schema/*` 报警 | Plan 400 §4.1.1 |
+| `ocl_guards` | 组合约束（前置/不变量/后置），供 `pkg/ocl` 与 migrator/validator 执行 | Plan 400 §4.1.1、Plan 402 |
+| `glossary_url` | 指向内部术语或 `docs/reference` 说明的链接，严禁引用外部百科 | AGENTS.md |
+
+### 生成/校验流程
+
+1. 执行 `make sqlc-generate`、`atlas migrate diff`、`make db-migrate-all` 以确保 Schema 表结构与生成脚本同步。
+2. 运行 `node scripts/generate-schema-registry.js`（命令名称以 Plan 400/300 实际脚本为准，可与 `scripts/generate-forms-from-openapi.ts`、`scripts/generate-columns-from-graphql.ts` 同步）生成 `schema-registry.json`。
+3. 运行 `node scripts/quality/architecture-validator.js --rule capabilityContracts`（或默认规则）以触发 `logs/plan400/schema/<timestamp>-dec-ocl.log`：
+
+```json
+{
+  "timestamp": "2025-11-26T13:45:02Z",
+  "objectType": "ORGANIZATION_UNIT",
+  "decBindingsMissing": [],
+  "oclViolations": [],
+  "schemaHash": "d4f84cdf8a51...",
+  "source": "node scripts/generate-schema-registry.js"
+}
+```
+
+若 `decBindingsMissing` 或 `oclViolations` 非空，视为违规，需先更新 Plan 400/402/403 再提交。
+
+---
+
+## 2. 日志模板（logs/plan40x）
+
+| 目录 | 内容 | 生成方式 | 核对脚本 |
+|------|------|----------|----------|
+| `logs/plan400/schema/` | Schema Registry 巡检、DEC/OCL 缺口、`schema-registry.json` 哈希 | `node scripts/quality/architecture-validator.js --rule capabilityContracts` 或 `npm run quality:preflight` | architecture-validator（新增 capabilityContracts 规则） |
+| `logs/plan400/snapshots/` | `cmd/tools/standardobject-snapshot-refresh` 运行结果、行数/耗时/快照版本 | Plan 400/401 交付的 `cmd/tools/standardobject-snapshot-refresh`（或等效 Job） | 手工审阅 + Plan 401 守卫 |
+| `logs/plan400/ui/` | Playwright `standard-object-*` 规格日志、`[OBS] standardObject.*` 事件截图说明 | `npm run test:e2e -- --grep standard-object` | `frontend/tests/e2e` + OBS 回放 |
+| `logs/plan400/manifest/` | OpenAPI/GraphQL 生成器输出（forms/columns manifest）、差异摘要 | `node scripts/generate-forms-from-openapi.ts`、`node scripts/generate-columns-from-graphql.ts` | Manifest diff 守卫 |
+| `logs/plan402/capability/` | Federate 能力巡检、`standardobject-migrator`/`validator`、Feature Flag 切换记录 | `node scripts/quality/architecture-validator.js --rule capabilityContracts`、`cmd/tools/standardobject-migrator` | architecture-validator（capabilityContracts）、Plan 402 |
+
+### 日志格式建议
+
+```text
+2025-11-26T14:05:11Z capability-check start
+Plan: 402-capability-contracts
+File: docs/development-plans/402-capability-contracts.md
+Checks:
+  - columns: OK
+  - entries: OK (Organization/Position/Shared)
+  - evidence: logs/plan402/capability, logs/plan400/schema, logs/plan400/snapshots
+Result: PASS
+```
+
+日志必须包含：
+- 时间戳（UTC）  
+- 所属计划/命令  
+- 关键校验项（columns/entries/evidence 等）  
+- PASS/FAIL 及回滚提示
+
+---
+
+## 3. 观测点与视点矩阵
+
+Plan 400 §4.8 定义了结构、运行、观察、协作四个视点。生成证据时需确保：
+- 每个视点至少对应一份日志或测试：
+  - 结构：`logs/plan400/schema/*` + `schema-registry.json`
+  - 运行：`logs/plan400/snapshots/*` + outbox 事件
+  - 观察：`logs/plan400/ui/*` + OBS 记录
+  - 协作：`logs/plan400/manifest/*` + PBAC/Manifest diff
+- PR 描述中应附上述日志路径，避免产生第二事实来源。
+
+---
+
+## 4. 常用命令速查
+
+```bash
+# 运行能力契约与 Schema Registry 巡检
+node scripts/quality/architecture-validator.js --rule capabilityContracts
+
+# 生成 Schema Registry 与前端表单/列
+node scripts/generate-schema-registry.js
+node scripts/generate-forms-from-openapi.ts
+node scripts/generate-columns-from-graphql.ts
+
+# 刷新快照（Plan 400/401 交付后使用）
+go run cmd/tools/standardobject-snapshot-refresh/main.go  # 或团队约定的等效命令
+```
+
+---
+
+如需新增证据或日志目录，请同步更新本指南与 Plan 400/402，并在 PR 中附上最新样例。

--- a/reports/architecture/architecture-validation.json
+++ b/reports/architecture/architecture-validation.json
@@ -1,8 +1,8 @@
 {
-  "timestamp": "2025-11-23T06:24:58.511Z",
+  "timestamp": "2025-11-23T10:17:22.036Z",
   "summary": {
-    "totalFiles": 228,
-    "passedFiles": 228,
+    "totalFiles": 420,
+    "passedFiles": 420,
     "failedFiles": 0,
     "totalViolations": 0,
     "violationsByType": {
@@ -10,7 +10,8 @@
       "ports": 0,
       "contracts": 0,
       "forbidden": 0,
-      "eslintExceptions": 0
+      "eslintExceptions": 0,
+      "capabilityContracts": 0
     }
   },
   "violations": []

--- a/reports/implementation-inventory.json
+++ b/reports/implementation-inventory.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2025-11-22T12:29:38.982Z",
+  "timestamp": "2025-11-23T06:47:39.965Z",
   "summary": {
     "openapiPaths": 49,
     "graphqlQueries": 25,

--- a/scripts/quality/architecture-validator.js
+++ b/scripts/quality/architecture-validator.js
@@ -91,6 +91,29 @@ const config = {
       enabled: true,
       targetPattern: /eslint-disable-next-line\s+camelcase/,
       requireReasonPattern: /eslint-disable-next-line\s+camelcase\s+--\s+\S/
+    },
+
+    // 能力契约矩阵
+    capabilityContracts: {
+      enabled: true,
+      path: 'docs/development-plans/402-capability-contracts.md',
+      requiredColumns: [
+        '模块 (Federate)',
+        '提供能力',
+        '依赖能力',
+        '视点覆盖',
+        '证据/日志'
+      ],
+      requiredEntries: [
+        'Organization Federate',
+        'Position Federate',
+        'Shared Federate'
+      ],
+      requiredEvidencePaths: [
+        'logs/plan402/capability',
+        'logs/plan400/schema',
+        'logs/plan400/snapshots'
+      ]
     }
   }
 };
@@ -106,6 +129,7 @@ const stats = {
     contracts: 0,
     forbidden: 0,
     eslintExceptions: 0,
+    capabilityContracts: 0,
     total: 0
   },
   fixedIssues: 0
@@ -506,6 +530,89 @@ class ForbiddenEndpointValidator {
   }
 }
 
+// 📘 能力契约验证器
+class CapabilityContractValidator {
+  static validate(options = {}, projectRoot = process.cwd()) {
+    const violations = [];
+    const contractPath = options.path
+      ? path.join(projectRoot, options.path)
+      : null;
+
+    if (!contractPath || !fs.existsSync(contractPath)) {
+      violations.push({
+        type: 'capabilityContracts',
+        line: 1,
+        column: 1,
+        message: `未找到能力契约文件 ${options.path || '<未配置>'}，请参考 Plan 402 创建/更新`,
+        code: 'capability-contract-missing',
+        severity: 'error'
+      });
+      return {
+        filePath: contractPath || (options.path || 'docs/development-plans/402-capability-contracts.md'),
+        violations
+      };
+    }
+
+    const content = fs.readFileSync(contractPath, 'utf8');
+    const requiredColumns = options.requiredColumns || [];
+    requiredColumns.forEach(column => {
+      if (!column) return;
+      if (!content.includes(column)) {
+        violations.push({
+          type: 'capabilityContracts',
+          line: this.findLine(content, column),
+          column: 1,
+          message: `能力矩阵缺少列 "${column}"，请对齐 402 计划`,
+          code: 'capability-column-missing',
+          severity: 'error'
+        });
+      }
+    });
+
+    const requiredEntries = options.requiredEntries || [];
+    requiredEntries.forEach(entry => {
+      if (!entry) return;
+      if (!content.includes(entry)) {
+        violations.push({
+          type: 'capabilityContracts',
+          line: 1,
+          column: 1,
+          message: `能力矩阵缺少 Federate "${entry}" 记录`,
+          code: 'capability-entry-missing',
+          severity: 'error'
+        });
+      }
+    });
+
+    const requiredEvidence = options.requiredEvidencePaths || [];
+    requiredEvidence.forEach(evidencePath => {
+      if (!evidencePath) return;
+      if (!content.includes(evidencePath)) {
+        violations.push({
+          type: 'capabilityContracts',
+          line: 1,
+          column: 1,
+          message: `能力矩阵未引用证据路径 "${evidencePath}"，请在表格或正文中注明`,
+          code: 'capability-evidence-missing',
+          severity: 'warning'
+        });
+      }
+    });
+
+    return {
+      filePath: contractPath,
+      violations
+    };
+  }
+
+  static findLine(content, token) {
+    if (!token) return 1;
+    const idx = content.indexOf(token);
+    if (idx === -1) return 1;
+    return content.substring(0, idx).split('\n').length;
+  }
+}
+
 // 🚀 主验证引擎
 class ArchitectureValidator {
   constructor(options = {}) {
@@ -619,6 +726,33 @@ class ArchitectureValidator {
     
     return this.violations;
   }
+
+  async validateAdditionalArtifacts() {
+    if (!this.isRuleEnabled('capabilityContracts') ||
+        !this.options.rules.capabilityContracts?.enabled) {
+      return;
+    }
+
+    const result = CapabilityContractValidator.validate(
+      this.options.rules.capabilityContracts,
+      this.options.projectRoot || process.cwd()
+    );
+
+    const filePath = result.filePath;
+    stats.totalFiles++;
+
+    if (result.violations.length > 0) {
+      stats.failedFiles++;
+      stats.violations.capabilityContracts += result.violations.length;
+      stats.violations.total += result.violations.length;
+      this.violations.push({
+        filePath,
+        violations: result.violations
+      });
+    } else {
+      stats.passedFiles++;
+    }
+  }
   
   generateReport(outPath = null) {
     const report = {
@@ -632,10 +766,11 @@ class ArchitectureValidator {
           cqrs: stats.violations.cqrs,
           ports: stats.violations.ports,
           contracts: stats.violations.contracts,
-          forbidden: stats.violations.forbidden,
-          eslintExceptions: stats.violations.eslintExceptions
-        }
-      },
+        forbidden: stats.violations.forbidden,
+        eslintExceptions: stats.violations.eslintExceptions,
+        capabilityContracts: stats.violations.capabilityContracts
+      }
+    },
       violations: this.violations
     };
     
@@ -678,12 +813,16 @@ class ArchitectureValidator {
     if (stats.violations.eslintExceptions > 0) {
       log.warning(`   📝 ESLint例外说明缺失: ${stats.violations.eslintExceptions} 个`);
     }
+    if (stats.violations.capabilityContracts > 0) {
+      log.warning(`   📘 能力契约违规: ${stats.violations.capabilityContracts} 个`);
+    }
 
     // 质量门禁判定
     const criticalViolations = stats.violations.cqrs +
       stats.violations.ports +
       stats.violations.forbidden +
-      stats.violations.eslintExceptions;
+      stats.violations.eslintExceptions +
+      stats.violations.capabilityContracts;
     if (criticalViolations > 0) {
       log.error(`🚫 质量门禁失败: ${criticalViolations} 个关键违规`);
       return false;
@@ -707,7 +846,9 @@ async function main() {
     contracts: 'apiContracts',
     forbidden: 'forbiddenEndpoints',
     'eslint-exception-comment': 'eslintExceptionComment',
-    'eslintExceptionComment': 'eslintExceptionComment'
+    'eslintExceptionComment': 'eslintExceptionComment',
+    capability: 'capabilityContracts',
+    'capabilityContracts': 'capabilityContracts'
   };
   let ruleFilter = null;
   if (ruleArgIndex !== -1 && args[ruleArgIndex + 1]) {
@@ -732,6 +873,7 @@ async function main() {
   
   try {
     await validator.validateDirectory(targetPath);
+    await validator.validateAdditionalArtifacts();
     const report = validator.generateReport(outPath);
     const success = validator.printSummary();
     


### PR DESCRIPTION
> 重要：远程分支策略为“主干开发 + 远程 PR 守卫”。远程 `master` 禁止直接推送；请通过短生命周期分支发起 PR（默认使用 squash-merge）。PR 必须关联 Issue 且通过所有 Required checks。

## 变更说明

- 概述本次变更的目的与范围：重构 SOM 相关文档，将 Plan 402 拆分为 402A~402E 独立文件，并新增 `docs/development-plans/402-capability-contracts.md`、`docs/reference/standard-object-evidence-guide.md` 等，便于阶段化执行与证据留存。
- 是否涉及后向不兼容变更：否，纯文档结构调整。
- 验证方式与可复现实验步骤：`git push` 触发 Plan 255/Plan 250 守卫；PR checks 全量运行（见下方链接）。
- 关联 Issue（必填）：Closes #44

## 对齐 CLAUDE.md 与 AGENTS.md 的合规检查

- [x] 诚实/谨慎：描述真实变更
- [ ] 临时方案：本次无 `// TODO-TEMPORARY`
- [ ] 新功能审批：不涉及新 API/服务
- [x] CQRS 分工：未改动实现，仍遵循 GraphQL/REST 分层
- [x] API 命名：文档内说明保持 camelCase
- [x] 契约命名自查：无新增契约字段
- [x] 权限契约：无新增端点
- [x] 测试与验证：Plan 255/Plan 250 守卫作为最小验证
- [x] 文档更新：所有相关文档已同步
- [ ] 实现清单：纯文档变更，未重新生成实现清单

## 文档治理与目录边界（Reference vs Plans）

- [x] `docs/development-plans/` 中新增/拆分的计划文件保持在 plans 目录
- [x] 未将进展类文档放入 `docs/reference/`
- [x] Reference 与 Plans 分界已在 `docs/README.md` 与 `00-README.md` 中保持一致
- [x] 新增 Reference（`standard-object-evidence-guide.md`）说明长期稳定性并添加索引

## CLAUDE 索引一致性检查（精简版原则落实）

- [x] 未改动 `CLAUDE.md`
- [x] 新增 Reference/Plans 均在索引中注册

## 风险与回滚

- 风险点：文档拆分若有遗漏，可能导致引用路径失效。
- 监控/告警：依赖文档 Review 与门禁（document-sync）。
- 回滚方案：可 revert 本 PR 恢复原结构。

## 证据与工件（必填）

- Actions 运行/工件链接：PR Checks → https://github.com/jacksonlee411/cube-castle/pull/43/checks
- 本地/CI 关键日志片段：`git push` 预推守卫日志（Plan 255/Plan 250）；`reports/architecture/architecture-validation.json` 记录最新一次守卫时间戳。
